### PR TITLE
Lint everything again

### DIFF
--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -81,7 +81,7 @@ impl MatchKey {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MatchOpts {
     pub bbox: Option<[u16; 4]>,
-    pub proximity: Option<[u16; 2]>
+    pub proximity: Option<[u16; 2]>,
 }
 
 impl Default for MatchOpts {

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -115,12 +115,13 @@ fn matching_test() {
         GridKey { phrase_id: 1, lang_set: 1 },
         GridKey { phrase_id: 1, lang_set: 2 },
         GridKey { phrase_id: 2, lang_set: 1 },
-        GridKey { phrase_id: 1, lang_set: 1 }
+        GridKey { phrase_id: 1, lang_set: 1 },
     ];
 
     let mut i = 0;
     for key in keys {
         for _j in 0..2 {
+            #[cfg_attr(rustfmt, rustfmt::skip)]
             let entries = vec![
                 GridEntry { id: i, x: (2 * i) as u16, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
                 GridEntry { id: i + 1, x: ((2 * i) + 1) as u16, y: 1, relev: 1., score: 7, source_phrase_hash: 0 },
@@ -137,10 +138,13 @@ fn matching_test() {
 
     let reader = GridStore::new(directory.path()).unwrap();
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -153,10 +157,13 @@ fn matching_test() {
         ]
     );
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -173,10 +180,13 @@ fn matching_test() {
         ]
     );
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 0 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 0 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: false },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: false },
@@ -193,10 +203,13 @@ fn matching_test() {
         ]
     );
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 26, y: 1, id: 14, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 15, source_phrase_hash: 0 }, matches_language: true },
@@ -213,10 +226,13 @@ fn matching_test() {
         ]
     );
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 3 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 3 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -233,18 +249,27 @@ fn matching_test() {
         ]
     );
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 1 }, lang_set: 1 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 1 }, lang_set: 1 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(records, []);
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 3, end: 4 }, lang_set: 1 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 3, end: 4 }, lang_set: 1 };
+    let records: Vec<_> =
+        reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
     assert_eq!(records, []);
 
-    let search_key = MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 };
-    let records: Vec<_> = reader.get_matching(&search_key, &MatchOpts { bbox: Some([26, 0, 41, 2]), proximity: None }).unwrap().collect();
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 };
+    let records: Vec<_> = reader
+        .get_matching(&search_key, &MatchOpts { bbox: Some([26, 0, 41, 2]), proximity: None })
+        .unwrap()
+        .collect();
     assert_eq!(
         records,
+        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 23, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 21, source_phrase_hash: 0 }, matches_language: true },

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -142,9 +142,9 @@ fn matching_test() {
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
     let records: Vec<_> =
         reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -161,9 +161,9 @@ fn matching_test() {
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 };
     let records: Vec<_> =
         reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -184,9 +184,9 @@ fn matching_test() {
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 0 };
     let records: Vec<_> =
         reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: false },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: false },
@@ -207,9 +207,9 @@ fn matching_test() {
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
     let records: Vec<_> =
         reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 26, y: 1, id: 14, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 15, source_phrase_hash: 0 }, matches_language: true },
@@ -230,9 +230,9 @@ fn matching_test() {
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 3 };
     let records: Vec<_> =
         reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: true },
@@ -267,9 +267,9 @@ fn matching_test() {
         .get_matching(&search_key, &MatchOpts { bbox: Some([26, 0, 41, 2]), proximity: None })
         .unwrap()
         .collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
     assert_eq!(
         records,
-        #[cfg_attr(rustfmt, rustfmt::skip)]
         [
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 23, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 21, source_phrase_hash: 0 }, matches_language: true },

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -1,14 +1,14 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::path::Path;
-use std::collections::BTreeMap;
-use std::cmp::Ordering;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use flatbuffers;
-use morton::deinterleave_morton;
-use rocksdb::{Direction, IteratorMode, DB};
-use ordered_float::OrderedFloat;
 use itertools::Itertools;
+use morton::deinterleave_morton;
+use ordered_float::OrderedFloat;
+use rocksdb::{Direction, IteratorMode, DB};
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;
@@ -41,10 +41,13 @@ fn get_vector<'a, T: 'a>(
 // takes ownership, and eagerly collects each group into a vector as it goes. So it's still
 // lazy-ish (in the sense that it doesn't advance beyond the current group), but more eager than
 // the itertools version
-fn somewhat_eager_groupby<T: Iterator, F, K>(mut it: T, key: F) -> impl Iterator<Item=(K, Vec<T::Item>)>
+fn somewhat_eager_groupby<T: Iterator, F, K>(
+    mut it: T,
+    key: F,
+) -> impl Iterator<Item = (K, Vec<T::Item>)>
 where
     K: Sized + Copy + PartialEq,
-    F: Fn(&T::Item) -> K
+    F: Fn(&T::Item) -> K,
 {
     let mut curr_key: Option<K> = None;
     let mut running_group: Vec<T::Item> = Vec::new();
@@ -63,7 +66,7 @@ where
                     None => {
                         curr_key = Some(k);
                         running_group.push(val);
-                    },
+                    }
                     Some(o) => {
                         if *o != k {
                             let mut out_vec = Vec::new();
@@ -98,13 +101,31 @@ where
 
 #[test]
 fn eager_test() {
-    let a = vec![1,1,1,2,3,4,4,4,7,7,8];
+    let a = vec![1, 1, 1, 2, 3, 4, 4, 4, 7, 7, 8];
     let b: Vec<_> = somewhat_eager_groupby(a.into_iter(), |x| *x).collect();
-    assert_eq!(b, vec![(1, vec![1, 1, 1]), (2, vec![2]), (3, vec![3]), (4, vec![4, 4, 4]), (7, vec![7, 7]), (8, vec![8])]);
+    assert_eq!(
+        b,
+        vec![
+            (1, vec![1, 1, 1]),
+            (2, vec![2]),
+            (3, vec![3]),
+            (4, vec![4, 4, 4]),
+            (7, vec![7, 7]),
+            (8, vec![8])
+        ]
+    );
 
-    let a = vec![(1,'a'),(1,'b'),(2,'b'),(3,'z'),(4,'a'),(4,'a')];
+    let a = vec![(1, 'a'), (1, 'b'), (2, 'b'), (3, 'z'), (4, 'a'), (4, 'a')];
     let b: Vec<_> = somewhat_eager_groupby(a.into_iter(), |x| (*x).0).collect();
-    assert_eq!(b, vec![(1, vec![(1, 'a'), (1, 'b')]), (2, vec![(2, 'b')]), (3, vec![(3, 'z')]), (4, vec![(4, 'a'), (4, 'a')])]);
+    assert_eq!(
+        b,
+        vec![
+            (1, vec![(1, 'a'), (1, 'b')]),
+            (2, vec![(2, 'b')]),
+            (3, vec![(3, 'z')]),
+            (4, vec![(4, 'a'), (4, 'a')])
+        ]
+    );
 }
 
 impl GridStore {
@@ -172,26 +193,26 @@ impl GridStore {
     pub fn get_matching(
         &self,
         match_key: &MatchKey,
-        match_opts: &MatchOpts
+        match_opts: &MatchOpts,
     ) -> Result<Box<dyn Iterator<Item = MatchEntry>>, Box<Error>> {
         match match_opts {
-            MatchOpts { bbox: None, .. } => {
-                Ok(Box::new(self.global_get_matching(match_key)?))
-            },
+            MatchOpts { bbox: None, .. } => Ok(Box::new(self.global_get_matching(match_key)?)),
             MatchOpts { bbox: Some(bbox), .. } => {
                 let bbox: [u16; 4] = bbox.clone();
                 let out = self.global_get_matching(match_key)?.filter(move |entry| {
-                    entry.grid_entry.x >= bbox[0] && entry.grid_entry.x <= bbox[2] &&
-                    entry.grid_entry.y >= bbox[1] && entry.grid_entry.y <= bbox[3]
+                    entry.grid_entry.x >= bbox[0]
+                        && entry.grid_entry.x <= bbox[2]
+                        && entry.grid_entry.y >= bbox[1]
+                        && entry.grid_entry.y <= bbox[3]
                 });
                 Ok(Box::new(out))
-            },
+            }
         }
     }
 
     fn global_get_matching(
         &self,
-        match_key: &MatchKey
+        match_key: &MatchKey,
     ) -> Result<impl Iterator<Item = MatchEntry>, Box<Error>> {
         let mut db_key: Vec<u8> = Vec::new();
         match_key.write_start_to(0, &mut db_key)?;
@@ -229,7 +250,8 @@ impl GridStore {
                     record_ref.1,
                     &record._tab,
                     PhraseRecord::VT_RELEV_SCORES,
-                ).unwrap();
+                )
+                .unwrap();
 
                 for rs_obj in rs_vec {
                     let relev_score = rs_obj.relev_score();
@@ -241,8 +263,8 @@ impl GridStore {
                         get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS)
                             .unwrap();
 
-                    let slot = coords_for_rs.entry((OrderedFloat(relev), score))
-                        .or_insert_with(|| vec![]);
+                    let slot =
+                        coords_for_rs.entry((OrderedFloat(relev), score)).or_insert_with(|| vec![]);
                     slot.push(coords.into_iter());
                 }
             }
@@ -254,47 +276,50 @@ impl GridStore {
                 let _ref_set = &ref_set;
                 let relev = relev.into_inner();
                 // for each relev/score, lazily k-way-merge the child entities by z-order curve value
-                let merged = coord_sets.into_iter()
+                let merged = coord_sets
+                    .into_iter()
                     .kmerge_by(|a, b| a.coord().cmp(&b.coord()) == Ordering::Greater)
                     .map(|coords_obj| (coords_obj.coord(), coords_obj));
 
                 // group together entries from different keys that have the same z-order coordinate
-                somewhat_eager_groupby(merged, |a| (*a).0).flat_map(move |(coord, coords_obj_group)| {
-                    let (x, y) = deinterleave_morton(coord);
+                somewhat_eager_groupby(merged, |a| (*a).0).flat_map(
+                    move |(coord, coords_obj_group)| {
+                        let (x, y) = deinterleave_morton(coord);
 
-                    // get all the feature IDs from all the entries with the same XY, and eagerly
-                    // combine them and sort descending if necessary (if there's only one entry,
-                    // it's already sorted)
-                    let all_ids: Vec<u32> = match coords_obj_group.len() {
-                        0 => Vec::new(),
-                        1 => coords_obj_group[0].1.ids().unwrap().iter().collect(),
-                        _ => {
-                            let mut ids = Vec::new();
-                            for (_, coords_obj) in coords_obj_group {
-                                ids.extend(coords_obj.ids().unwrap().iter());
+                        // get all the feature IDs from all the entries with the same XY, and eagerly
+                        // combine them and sort descending if necessary (if there's only one entry,
+                        // it's already sorted)
+                        let all_ids: Vec<u32> = match coords_obj_group.len() {
+                            0 => Vec::new(),
+                            1 => coords_obj_group[0].1.ids().unwrap().iter().collect(),
+                            _ => {
+                                let mut ids = Vec::new();
+                                for (_, coords_obj) in coords_obj_group {
+                                    ids.extend(coords_obj.ids().unwrap().iter());
+                                }
+                                ids.sort_by(|a, b| b.cmp(a));
+                                ids.dedup();
+                                ids
                             }
-                            ids.sort_by(|a, b| b.cmp(a));
-                            ids.dedup();
-                            ids
-                        }
-                    };
+                        };
 
-                    all_ids.into_iter().map(move |id_comp| {
-                        let id = id_comp >> 8;
-                        let source_phrase_hash = (id_comp & 255) as u8;
-                        MatchEntry {
-                            grid_entry: GridEntry {
-                                relev,
-                                score,
-                                x,
-                                y,
-                                id,
-                                source_phrase_hash,
-                            },
-                            matches_language: matches_language,
-                        }
-                    })
-                })
+                        all_ids.into_iter().map(move |id_comp| {
+                            let id = id_comp >> 8;
+                            let source_phrase_hash = (id_comp & 255) as u8;
+                            MatchEntry {
+                                grid_entry: GridEntry {
+                                    relev,
+                                    score,
+                                    x,
+                                    y,
+                                    id,
+                                    source_phrase_hash,
+                                },
+                                matches_language: matches_language,
+                            }
+                        })
+                    },
+                )
             })
         });
         Ok(out)


### PR DESCRIPTION
#12 landed without CI requiring it to be linted, because CI wasn't yet turned on when I pushed its last commit. This branch lints everything again.

As originally configured, this PR was explosively big, because all of the long fixture-ish stuff in the tests got split out into many lines. I compromised here by exempting some of it with inline attrs to keep the tests from dominating all the files. It's still fairly disruptive though, so we should figure out when to merge it to avoid ruining anybody's day.