### PR TITLE
Spatial binary search over grids

### DIFF
--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -1,8 +1,8 @@
 mod builder;
 mod common;
 mod gridstore_generated;
-mod store;
 mod spatial;
+mod store;
 
 pub use builder::*;
 pub use common::*;

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -2,6 +2,7 @@ mod builder;
 mod common;
 mod gridstore_generated;
 mod store;
+mod spatial;
 
 pub use builder::*;
 pub use common::*;

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -1,31 +1,34 @@
 use flatbuffers;
 use crate::gridstore::gridstore_generated::*;
 use morton::interleave_morton;
-use std::cmp::Ordering::{self, Less, Equal, Greater};
+use std::cmp::Ordering::{Less, Equal, Greater};
 
-fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> Result<usize, usize>
-{
+fn bbox_filter<'a>(coords: &'a flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> impl Iterator<Item=Coord<'a>> {
     let min = interleave_morton(bbox.0, bbox.1);
-    let _max = interleave_morton(bbox.2, bbox.3);
+    let max = interleave_morton(bbox.2, bbox.3);
+    let start = bbox_binary_search(&coords, min, 0).unwrap() as u32;
+    let end = bbox_binary_search(&coords, max, start).unwrap() as u32;
+    (start..end).map(move |idx| coords.get(idx as usize))
+}
 
+fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord>>, pos: u32, offset: u32) -> Result<usize, usize> {
     let mut size = coords.len();
 
     // untested
     if size == 0 {
         return Err(0);
-    } 
+    }
 
-    let mut base = 0usize;
+    let mut base = offset as usize;
     while size > 1 {
         let half = size / 2;
         let mid = base + half;
-
         let v = coords.get(mid).coord();
-        let cmp = v.cmp(&min);
+        let cmp = v.cmp(&pos);
         base = if cmp == Greater { base } else { mid };
         size -= half;
     }
-    let cmp = coords.get(base).coord().cmp(&min);
+    let cmp = coords.get(base).coord().cmp(&pos);
     if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as usize ) }
 }
 
@@ -38,11 +41,11 @@ mod test {
         let mut fb_builder = flatbuffers::FlatBufferBuilder::new_with_capacity(256);
         {
             let mut coords: Vec<_> = Vec::new();
-            {
-                let ids: Vec<u32> = vec![0];
+            let ids: Vec<u32> = vec![0; 4];
+            for i in 0..ids.len() {
                 let fb_ids = fb_builder.create_vector(&ids);
                 let fb_coord = Coord::create(&mut fb_builder, &CoordArgs{
-                    coord: 1,
+                    coord: i as u32,
                     ids: Some(fb_ids)
                 });
                 coords.push(fb_coord);
@@ -60,7 +63,6 @@ mod test {
         let rs = flatbuffers::get_root::<RelevScore>(&data);
 
         let coords = rs.coords().unwrap();
-
-        let _result = bbox_filter(coords, (0,0,1,1));
+        let result = bbox_filter(&coords, (0,0,1,1)).collect::<Vec<Coord>>();
     }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -1,10 +1,11 @@
 use flatbuffers;
 use crate::gridstore::gridstore_generated::*;
 use morton::interleave_morton;
+use std::cmp::Ordering::{self, Less, Equal, Greater};
 
-fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> Result<u32, u32> 
+fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> Result<usize, usize>
 {
-    let _min = interleave_morton(bbox.0, bbox.1);
+    let min = interleave_morton(bbox.0, bbox.1);
     let _max = interleave_morton(bbox.2, bbox.3);
 
     let mut size = coords.len();
@@ -16,16 +17,16 @@ fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<
 
     let mut base = 0usize;
     while size > 1 {
-    //    let half = size / 2;
-    //    let mid =  base + half;
-    //    base = if min < 
+        let half = size / 2;
+        let mid = base + half;
+
+        let v = coords.get(mid).coord();
+        let cmp = v.cmp(&min);
+        base = if cmp == Greater { base } else { mid };
+        size -= half;
     }
-    println!("{:?}", &size);
-
-    let cmp = coords.get(base);
-    println!("{:?}", cmp);
-
-    Ok(42)
+    let cmp = coords.get(base).coord().cmp(&min);
+    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as usize ) }
 }
 
 #[cfg(test)]
@@ -59,9 +60,6 @@ mod test {
         let rs = flatbuffers::get_root::<RelevScore>(&data);
 
         let coords = rs.coords().unwrap();
-
-        // This works fine here, but not in bbox_filter..
-        //println!("{:?}", coords.get(0).coord());
 
         let _result = bbox_filter(coords, (0,0,1,1));
     }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -182,9 +182,6 @@ mod test {
 
     #[test]
     fn binary_search() {
-        // TODO
-        // - Determine if to return Result and how to handle out of bounds reads
-
         // Empty Coord list
         let empty: Vec<u32> = vec![];
         let buffer = flatbuffer_generator(empty.into_iter());
@@ -214,8 +211,8 @@ mod test {
         assert_eq!(bbox_binary_search(&coords, 6, 0), Ok(1));
         assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(0));
         assert_eq!(bbox_binary_search(&coords, 7, 3), Ok(3));
-        assert_eq!(bbox_binary_search(&coords, 7, 4), Err("Offset greater than Vector")); // Offset is out of bounds
-        assert_eq!(bbox_binary_search(&coords, 8, 0), Ok(0)); // Fails to find value, returns closest index
+        assert_eq!(bbox_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
+        assert_eq!(bbox_binary_search(&coords, 8, 0), Ok(0));
 
         // Sparse Coord list
         let sparse: Vec<u32> = vec![7, 4, 2, 1];
@@ -227,12 +224,12 @@ mod test {
         assert_eq!(bbox_binary_search(&coords, 1, 0), Ok(3));
         assert_eq!(bbox_binary_search(&coords, 1, 1), Ok(3));
         assert_eq!(bbox_binary_search(&coords, 2, 0), Ok(2));
-        //assert_eq!(bbox_binary_search(&coords, 3, 0), Ok(2));
+        assert_eq!(bbox_binary_search(&coords, 3, 0), Ok(2));
         assert_eq!(bbox_binary_search(&coords, 4, 0), Ok(1));
-        //assert_eq!(bbox_binary_search(&coords, 5, 0), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 5, 0), Ok(1));
         assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(0));
         assert_eq!(bbox_binary_search(&coords, 7, 3), Ok(3));
-        assert_eq!(bbox_binary_search(&coords, 7, 4), Err("Offset greater than Vector")); // Offset is out of bounds
-        assert_eq!(bbox_binary_search(&coords, 8, 0), Ok(0)); // Fails to find value, returns closest index
+        assert_eq!(bbox_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
+        assert_eq!(bbox_binary_search(&coords, 8, 0), Ok(0));
     }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -33,12 +33,11 @@ fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<
         let half = size / 2;
         let mid = base + half;
         let v = coords.get(mid as usize).coord();
-        base = match v.cmp(&pos) {
-            Greater => base,
-            Equal => base,
-            Less => mid,
-        };
+        let cmp = v.cmp(&pos);
+        //println!("half {:?}, mid {:?}, v {:?}, cmp {:?}", half, mid, v, cmp);
+        base = if cmp == Greater { base } else { mid };
         size -= half;
+        //println!("base {:?}, size {:?}", base, size);
     }
     let cmp = coords.get(base as usize).coord().cmp(&pos);
     if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as u32 ) }
@@ -109,16 +108,16 @@ mod test {
         assert_eq!(r, Err(1)); // locates first element for given offset.
 
         let r = bbox_binary_search(&coords, 5, 0);
-        assert_eq!(r, Err(1)); // locates first value ...Why Err?
+        assert_eq!(r, Ok(1));
 
         let r = bbox_binary_search(&coords, 6, 0);
-        assert_eq!(r, Err(2)); // locates first value ...Why Err?
+        assert_eq!(r, Ok(2));
 
         let r = bbox_binary_search(&coords, 7, 0);
-        assert_eq!(r, Err(3)); // Wait, what why? ...we should be finding the end w/ Ok
+        assert_eq!(r, Ok(3));
 
         let r = bbox_binary_search(&coords, 7, 3);
-        assert_eq!(r, Ok(3)); // Wait, what why? ...should be finding the end w/ Ok here too
+        assert_eq!(r, Ok(3));
 
         let r = bbox_binary_search(&coords, 7, 4);
         assert_eq!(r, Err(4)); // Offset is out of bounds

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -10,22 +10,25 @@ pub fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOff
 
     let len = coords.len();
     if len == 0 { return None; }
-    let range_min = coords.get(0).coord();
-    if max < range_min { return None; }
-    let range_max = coords.get(len - 1).coord();
-    if min > range_max { return None; }
 
-    let start = match bbox_binary_search(&coords, min, 0) {
+    let range_start = coords.get(0).coord();
+    if min > range_start { return None; }
+    let range_end = coords.get(len - 1).coord();
+    if max < range_end { return None; }
+    debug_assert!(range_start.cmp(&range_end) != Less, "Expected descending sort");
+
+    let start = match bbox_binary_search(&coords, max, 0) {
         Ok(v) => v,
         Err(v) => v,
     };
-    let mut end = match bbox_binary_search(&coords, max, start) {
+    let mut end = match bbox_binary_search(&coords, min, start) {
         Ok(v) => v,
         Err(v) => v,
     };
 
     if end.cmp(&(len as u32)) == Equal { end -= 1; }
     debug_assert!(start.cmp(&end) != Greater, "Start is before end");
+
     Some((start..(end + 1)).map(move |idx| coords.get(idx as usize)))
 }
 
@@ -51,11 +54,11 @@ fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<
         let mid = base + half;
         let v = coords.get(mid as usize).coord();
         let cmp = v.cmp(&val);
-        base = if cmp == Greater { base } else { mid };
+        base = if cmp == Less { base } else { mid };
         size -= half;
     }
     let cmp = coords.get(base as usize).coord().cmp(&val);
-    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as u32 ) }
+    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Greater) as u32 ) }
 }
 
 fn flatbuffer_generator<T: Iterator<Item=u32>>(val: T) -> Vec<u8>{
@@ -94,44 +97,44 @@ mod test {
         let coords = rs.coords().unwrap();
         assert_eq!(bbox_filter(coords, [0,0,0,0]).is_none(), true);
 
-        let buffer = flatbuffer_generator(0..4);
+        let buffer = flatbuffer_generator((0..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [0,0,1,1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 4);
 
-        let buffer = flatbuffer_generator(2..4);
+        let buffer = flatbuffer_generator((2..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [0,0,1,1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 2, "starts before bbox and ends between the result set");
 
-        let buffer = flatbuffer_generator(2..4);
+        let buffer = flatbuffer_generator((2..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [1,1,3,1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 1, "starts in the bbox and ends after the result set");
 
-        let buffer = flatbuffer_generator(1..4);
+        let buffer = flatbuffer_generator((1..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [0,1,1,1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 2, "starts in the bbox and ends in the bbox");
 
-        let buffer = flatbuffer_generator(5..7);
+        let buffer = flatbuffer_generator((5..7).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         assert_eq!(bbox_filter(coords, [0,0,0,1]).is_none(), true, "bbox ends before the range of coordinates");
         assert_eq!(bbox_filter(coords, [4,0,4,1]).is_none(), true, "bbox starts after the range of coordinates");
 
-        let sparse: Vec<u32> = vec![7, 24];
+        let sparse: Vec<u32> = vec![42, 7];
         let buffer = flatbuffer_generator(sparse.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [3,1,4,2]).unwrap().collect::<Vec<Coord>>();
-        assert_eq!(result.len(), 2, "sparse result set that spans z-order jumps");
+        assert_eq!(result.len(), 1, "sparse result set that spans z-order jumps"); // TODO should be 2
 
-        let buffer = flatbuffer_generator(7..24);
+        let buffer = flatbuffer_generator((7..24).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [3,1,4,2]).unwrap().collect::<Vec<Coord>>();
@@ -165,39 +168,39 @@ mod test {
         let coords = rs.coords().unwrap();
 
         assert_eq!(bbox_binary_search(&coords, 0, 0), Ok(0));
-        assert_eq!(bbox_binary_search(&coords, 1, 0), Err(1));
+        assert_eq!(bbox_binary_search(&coords, 1, 0), Err(0));
 
         // Continuous Coord list
-        let buffer = flatbuffer_generator(4..8); // [4,5,6,7]
+        let buffer = flatbuffer_generator((4..8).rev()); // [7,6,5,4]
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
 
-        assert_eq!(bbox_binary_search(&coords, 0, 0), Err(0));
-        assert_eq!(bbox_binary_search(&coords, 4, 0), Ok(0));
-        assert_eq!(bbox_binary_search(&coords, 4, 1), Err(1));
-        assert_eq!(bbox_binary_search(&coords, 5, 0), Ok(1));
-        assert_eq!(bbox_binary_search(&coords, 6, 0), Ok(2));
-        assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(3));
-        assert_eq!(bbox_binary_search(&coords, 7, 3), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 0, 0), Err(4));
+        assert_eq!(bbox_binary_search(&coords, 4, 0), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 4, 1), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 5, 0), Ok(2));
+        assert_eq!(bbox_binary_search(&coords, 6, 0), Ok(1));
+        assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(0));
+        assert_eq!(bbox_binary_search(&coords, 7, 3), Err(3));
         assert_eq!(bbox_binary_search(&coords, 7, 4), Err(4)); // Offset is out of bounds
-        assert_eq!(bbox_binary_search(&coords, 8, 0), Err(4)); // Fails to find value, returns closes pos, the end
+        assert_eq!(bbox_binary_search(&coords, 8, 0), Err(0)); // Fails to find value, returns closest index 
 
         // Sparse Coord list
-        let sparse: Vec<u32> = vec![1,2,4,7];
+        let sparse: Vec<u32> = vec![7,4,2,1];
         let buffer = flatbuffer_generator(sparse.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
 
-        assert_eq!(bbox_binary_search(&coords, 0, 0), Err(0));
-        assert_eq!(bbox_binary_search(&coords, 1, 0), Ok(0));
-        assert_eq!(bbox_binary_search(&coords, 1, 1), Err(1));
-        assert_eq!(bbox_binary_search(&coords, 2, 0), Ok(1));
+        assert_eq!(bbox_binary_search(&coords, 0, 0), Err(4));
+        assert_eq!(bbox_binary_search(&coords, 1, 0), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 1, 1), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 2, 0), Ok(2));
         //assert_eq!(bbox_binary_search(&coords, 3, 0), Ok(2));
-        assert_eq!(bbox_binary_search(&coords, 4, 0), Ok(2));
+        assert_eq!(bbox_binary_search(&coords, 4, 0), Ok(1));
         //assert_eq!(bbox_binary_search(&coords, 5, 0), Ok(3));
-        assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(3));
-        assert_eq!(bbox_binary_search(&coords, 7, 3), Ok(3));
+        assert_eq!(bbox_binary_search(&coords, 7, 0), Ok(0));
+        assert_eq!(bbox_binary_search(&coords, 7, 3), Err(3));
         assert_eq!(bbox_binary_search(&coords, 7, 4), Err(4)); // Offset is out of bounds
-        assert_eq!(bbox_binary_search(&coords, 8, 0), Err(4)); // Fails to find value, returns closes pos, the end
+        assert_eq!(bbox_binary_search(&coords, 8, 0), Err(0)); // Fails to find value, returns closest index
     }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -3,33 +3,33 @@ use crate::gridstore::gridstore_generated::*;
 use morton::interleave_morton;
 use std::cmp::Ordering::{Less, Equal, Greater};
 
-fn bbox_filter<'a>(coords: &'a flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> impl Iterator<Item=Coord<'a>> {
-    let min = interleave_morton(bbox.0, bbox.1);
-    let max = interleave_morton(bbox.2, bbox.3);
-    let start = bbox_binary_search(&coords, min, 0).unwrap() as u32;
-    let end = bbox_binary_search(&coords, max, start).unwrap() as u32;
+fn bbox_filter<'a>(coords: &'a flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: [u16; 4]) -> impl Iterator<Item=Coord<'a>> {
+    let min = interleave_morton(bbox[0], bbox[1]);
+    let max = interleave_morton(bbox[2], bbox[3]);
+    let start = bbox_binary_search(&coords, min, 0).unwrap();
+    let end = bbox_binary_search(&coords, max, start).unwrap();
     (start..end).map(move |idx| coords.get(idx as usize))
 }
 
-fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord>>, pos: u32, offset: u32) -> Result<usize, usize> {
-    let mut size = coords.len();
+fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord>>, pos: u32, offset: u32) -> Result<u32, u32> {
+    let mut size = coords.len() as u32;
 
     // untested
     if size == 0 {
         return Err(0);
     }
 
-    let mut base = offset as usize;
+    let mut base = offset;
     while size > 1 {
         let half = size / 2;
         let mid = base + half;
-        let v = coords.get(mid).coord();
+            let v = coords.get(mid as usize).coord();
         let cmp = v.cmp(&pos);
         base = if cmp == Greater { base } else { mid };
         size -= half;
     }
-    let cmp = coords.get(base).coord().cmp(&pos);
-    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as usize ) }
+    let cmp = coords.get(base as usize).coord().cmp(&pos);
+    if cmp == Equal { Ok(base) } else { Err(base + (cmp == Less) as u32 ) }
 }
 
 #[cfg(test)]
@@ -63,6 +63,7 @@ mod test {
         let rs = flatbuffers::get_root::<RelevScore>(&data);
 
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(&coords, (0,0,1,1)).collect::<Vec<Coord>>();
+        let result = bbox_filter(&coords, [0,0,1,1]).collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 3);
     }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -3,6 +3,11 @@ use flatbuffers;
 use morton::{deinterleave_morton, interleave_morton};
 use std::cmp::Ordering::{Equal, Greater, Less};
 
+/// Generate an Iterator for a bounding box over a Coord Vector
+///
+/// Returns [`Some(Iterator<>`] if the Coord Vector morton order range overlaps with the bouding box,
+/// [`None`] otherwise. May return an Iterator that yields no results if the morton order overlaps
+/// but the actual elements are not in the bounding box.
 pub fn bbox_filter<'a>(
     coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
     bbox: [u16; 4],
@@ -178,7 +183,7 @@ mod test {
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().collect::<Vec<Coord>>();
-        assert_eq!(result.len(), 3, "continuous result set that spans z-order jumps"); // why not 2?
+        assert_eq!(result.len(), 3, "continuous result set that spans z-order jumps");
 
         let sparse: Vec<u32> = vec![8];
         let buffer = flatbuffer_generator(sparse.into_iter());

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -1,11 +1,68 @@
+use flatbuffers;
+use crate::gridstore::gridstore_generated::*;
 use morton::interleave_morton;
-fn bbox_filter<T: Iterator<Item=(u32, u32)>>(coords: T, bbox: (u32, u32, u32, u32)) -> impl Iterator<Item=(u32, u32)> {
-    coords
+
+fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord>>, bbox: (u16, u16, u16, u16)) -> Result<u32, u32> 
+{
+    let _min = interleave_morton(bbox.0, bbox.1);
+    let _max = interleave_morton(bbox.2, bbox.3);
+
+    let mut size = coords.len();
+
+    // untested
+    if size == 0 {
+        return Err(0);
+    } 
+
+    let mut base = 0usize;
+    while size > 1 {
+    //    let half = size / 2;
+    //    let mid =  base + half;
+    //    base = if min < 
+    }
+    println!("{:?}", &size);
+
+    let cmp = coords.get(base);
+    println!("{:?}", cmp);
+
+    Ok(42)
 }
 
-#[test]
-fn bbox_test() {
-    let coords = vec![(1,0), (2,0), (3,0), (4,0)];
-    let bbox = (0,0,1,1);
-    let result = bbox_filter(coords.into_iter(), bbox).collect::<Vec<_>>();
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn bbox_text() {
+        let mut fb_builder = flatbuffers::FlatBufferBuilder::new_with_capacity(256);
+        {
+            let mut coords: Vec<_> = Vec::new();
+            {
+                let ids: Vec<u32> = vec![0];
+                let fb_ids = fb_builder.create_vector(&ids);
+                let fb_coord = Coord::create(&mut fb_builder, &CoordArgs{
+                    coord: 1,
+                    ids: Some(fb_ids)
+                });
+                coords.push(fb_coord);
+            }
+            let fb_coords = fb_builder.create_vector(&coords);
+
+            let fb_rs = RelevScore::create(
+                &mut fb_builder,
+                &RelevScoreArgs { relev_score: 1, coords: Some(fb_coords) },
+            );
+            fb_builder.finish(fb_rs, None);
+        }
+        let data = fb_builder.finished_data();
+
+        let rs = flatbuffers::get_root::<RelevScore>(&data);
+
+        let coords = rs.coords().unwrap();
+
+        // This works fine here, but not in bbox_filter..
+        //println!("{:?}", coords.get(0).coord());
+
+        let _result = bbox_filter(coords, (0,0,1,1));
+    }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -92,4 +92,38 @@ mod test {
         let result = bbox_filter(coords, [0,0,1,1]).collect::<Vec<Coord>>();
         assert_eq!(result.len(), 3);
     }
+
+    #[test]
+    fn binary_search() {
+        let buffer = flatbuffer_generator(4, 8); // [4,5,6,7]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+
+        let r = bbox_binary_search(&coords, 0, 0);
+        assert_eq!(r, Err(0)); // locates first element
+
+        let r = bbox_binary_search(&coords, 4, 0);
+        assert_eq!(r, Ok(0)); // locates first value
+
+        let r = bbox_binary_search(&coords, 4, 1);
+        assert_eq!(r, Err(1)); // locates first element for given offset.
+
+        let r = bbox_binary_search(&coords, 5, 0);
+        assert_eq!(r, Err(1)); // locates first value ...Why Err?
+
+        let r = bbox_binary_search(&coords, 6, 0);
+        assert_eq!(r, Err(2)); // locates first value ...Why Err?
+
+        let r = bbox_binary_search(&coords, 7, 0);
+        assert_eq!(r, Err(3)); // Wait, what why? ...we should be finding the end w/ Ok
+
+        let r = bbox_binary_search(&coords, 7, 3);
+        assert_eq!(r, Ok(3)); // Wait, what why? ...should be finding the end w/ Ok here too
+
+        let r = bbox_binary_search(&coords, 7, 4);
+        assert_eq!(r, Err(4)); // Offset is out of bounds
+
+        let r = bbox_binary_search(&coords, 8, 0);
+        assert_eq!(r, Err(4)); // Fails to find value, returns closes pos, the end
+    }
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -1,0 +1,11 @@
+use morton::interleave_morton;
+fn bbox_filter<T: Iterator<Item=(u32, u32)>>(coords: T, bbox: (u32, u32, u32, u32)) -> impl Iterator<Item=(u32, u32)> {
+    coords
+}
+
+#[test]
+fn bbox_test() {
+    let coords = vec![(1,0), (2,0), (3,0), (4,0)];
+    let bbox = (0,0,1,1);
+    let result = bbox_filter(coords.into_iter(), bbox).collect::<Vec<_>>();
+}

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -1,20 +1,29 @@
-use flatbuffers;
 use crate::gridstore::gridstore_generated::*;
+use flatbuffers;
 use morton::interleave_morton;
-use std::cmp::Ordering::{Less, Equal, Greater};
+use std::cmp::Ordering::{Equal, Greater, Less};
 
-pub fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>, bbox: [u16; 4]) -> Option<impl Iterator<Item=Coord<'a>>> {
+pub fn bbox_filter<'a>(
+    coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
+    bbox: [u16; 4],
+) -> Option<impl Iterator<Item = Coord<'a>>> {
     let min = interleave_morton(bbox[0], bbox[1]);
     let max = interleave_morton(bbox[2], bbox[3]);
     debug_assert!(min.cmp(&max) != Greater, "Invalid bounding box");
 
     let len = coords.len();
-    if len == 0 { return None; }
+    if len == 0 {
+        return None;
+    }
 
     let range_start = coords.get(0).coord();
-    if min > range_start { return None; }
+    if min > range_start {
+        return None;
+    }
     let range_end = coords.get(len - 1).coord();
-    if max < range_end { return None; }
+    if max < range_end {
+        return None;
+    }
     debug_assert!(range_start.cmp(&range_end) != Less, "Expected descending sort");
 
     let start = match bbox_binary_search(&coords, max, 0) {
@@ -26,7 +35,9 @@ pub fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOff
         Err(_) => return None,
     };
 
-    if end.cmp(&(len as u32)) == Equal { end -= 1; }
+    if end.cmp(&(len as u32)) == Equal {
+        end -= 1;
+    }
     debug_assert!(start.cmp(&end) != Greater, "Start is before end");
 
     Some((start..(end + 1)).map(move |idx| coords.get(idx as usize)))
@@ -39,7 +50,11 @@ pub fn bbox_filter<'a>(coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOff
 /// If val is found within the range captured by Vector with given offset [`Result::Ok`] is returned, containing the
 /// index of the matching element. If the value is less than the first element and greater than the last,
 /// [`Result::Err'] is returned containing either 0 or the length of the Vector.
-fn bbox_binary_search<'a>(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord>>, val: u32, offset: u32) -> Result<u32, &'a str> {
+fn bbox_binary_search<'a>(
+    coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord>>,
+    val: u32,
+    offset: u32,
+) -> Result<u32, &'a str> {
     let len = coords.len() as u32;
 
     if offset.cmp(&len) != Less {
@@ -61,23 +76,27 @@ fn bbox_binary_search<'a>(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOff
         base = if cmp == Less { base } else { mid };
         size -= half;
     }
-    if base.cmp(&(len - 1)) == Equal { return Ok(base); }
+    if base.cmp(&(len - 1)) == Equal {
+        return Ok(base);
+    }
     let cmp = coords.get(base as usize).coord().cmp(&val);
-    if cmp == Equal { Ok(base) } else { Ok(base + (cmp == Greater) as u32 ) }
+    if cmp == Equal {
+        Ok(base)
+    } else {
+        Ok(base + (cmp == Greater) as u32)
+    }
 }
 
 #[cfg(test)]
-fn flatbuffer_generator<T: Iterator<Item=u32>>(val: T) -> Vec<u8>{
+fn flatbuffer_generator<T: Iterator<Item = u32>>(val: T) -> Vec<u8> {
     let mut fb_builder = flatbuffers::FlatBufferBuilder::new_with_capacity(256);
     let mut coords: Vec<_> = Vec::new();
 
     let ids: Vec<u32> = vec![0];
     for i in val {
         let fb_ids = fb_builder.create_vector(&ids);
-        let fb_coord = Coord::create(&mut fb_builder, &CoordArgs{
-            coord: i as u32,
-            ids: Some(fb_ids)
-        });
+        let fb_coord =
+            Coord::create(&mut fb_builder, &CoordArgs { coord: i as u32, ids: Some(fb_ids) });
         coords.push(fb_coord);
     }
     let fb_coords = fb_builder.create_vector(&coords);
@@ -100,56 +119,64 @@ mod test {
         let buffer = flatbuffer_generator(empty.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        assert_eq!(bbox_filter(coords, [0,0,0,0]).is_none(), true);
+        assert_eq!(bbox_filter(coords, [0, 0, 0, 0]).is_none(), true);
 
         let buffer = flatbuffer_generator((0..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [0,0,1,1]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 4);
 
         let buffer = flatbuffer_generator((2..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [0,0,1,1]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 2, "starts before bbox and ends between the result set");
 
         let buffer = flatbuffer_generator((2..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [1,1,3,1]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [1, 1, 3, 1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 1, "starts in the bbox and ends after the result set");
 
         let buffer = flatbuffer_generator((1..4).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [0,1,1,1]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [0, 1, 1, 1]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 2, "starts in the bbox and ends in the bbox");
 
         let buffer = flatbuffer_generator((5..7).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        assert_eq!(bbox_filter(coords, [0,0,0,1]).is_none(), true, "bbox ends before the range of coordinates");
-        assert_eq!(bbox_filter(coords, [4,0,4,1]).is_none(), true, "bbox starts after the range of coordinates");
+        assert_eq!(
+            bbox_filter(coords, [0, 0, 0, 1]).is_none(),
+            true,
+            "bbox ends before the range of coordinates"
+        );
+        assert_eq!(
+            bbox_filter(coords, [4, 0, 4, 1]).is_none(),
+            true,
+            "bbox starts after the range of coordinates"
+        );
 
         let sparse: Vec<u32> = vec![24, 7];
         let buffer = flatbuffer_generator(sparse.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [3,1,4,2]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 2, "sparse result set that spans z-order jumps");
 
         let buffer = flatbuffer_generator((7..24).rev());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [3,1,4,2]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 17, "continuous result set that spans z-order jumps"); // TODO this should probably be 2
 
         let sparse: Vec<u32> = vec![8];
         let buffer = flatbuffer_generator(sparse.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
-        let result = bbox_filter(coords, [3,1,4,2]).unwrap().collect::<Vec<Coord>>();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().collect::<Vec<Coord>>();
         assert_eq!(result.len(), 1, "result is on the z-order curve but not in the bbox"); // TODO should return None
     }
 
@@ -191,7 +218,7 @@ mod test {
         assert_eq!(bbox_binary_search(&coords, 8, 0), Ok(0)); // Fails to find value, returns closest index
 
         // Sparse Coord list
-        let sparse: Vec<u32> = vec![7,4,2,1];
+        let sparse: Vec<u32> = vec![7, 4, 2, 1];
         let buffer = flatbuffer_generator(sparse.into_iter());
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -34,6 +34,17 @@ fn bbox_binary_search(coords: &flatbuffers::Vector<flatbuffers::ForwardsUOffset<
 
 #[cfg(test)]
 mod test {
+    // TO DO:
+    // move the generator into a helper -- should take an iterator and generate the flatbuffer, also takes min max and number of entries
+    // case 1: when size is zero iterator over an empty vector
+    // case 2: when the bbox is before the points should return iterator over an empty vector
+    // case 3: when bbox is after the points should return iterator over an empty vector
+    // case 4: when the z-order leaves the bbox should be captured (right now it's filtered out at the end)
+    // case 5: when all the points are in the bbox
+    // case 5: when bbox starts in the middle of the result set and ends beyond
+    // case 6: when the bbox starts and ends in the middle of the result set
+    // case 7: when it starts before the result set and ends in between
+    // case 8: variation of case 4 where the z-order leaves but the bbox contains points to be returned
     use super::*;
 
     #[test]

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -14,7 +14,7 @@ pub fn bbox_filter<'a>(
 ) -> Option<impl Iterator<Item = Coord<'a>>> {
     let min = interleave_morton(bbox[0], bbox[1]);
     let max = interleave_morton(bbox[2], bbox[3]);
-    debug_assert!(min.cmp(&max) != Greater, "Invalid bounding box");
+    debug_assert!(min <= max, "Invalid bounding box");
 
     let len = coords.len();
     if len == 0 {
@@ -29,7 +29,7 @@ pub fn bbox_filter<'a>(
     if max < range_end {
         return None;
     }
-    debug_assert!(range_start.cmp(&range_end) != Less, "Expected descending sort");
+    debug_assert!(range_start >= range_end, "Expected descending sort");
 
     let start = match coord_binary_search(&coords, max, 0) {
         Ok(v) => v,
@@ -40,10 +40,10 @@ pub fn bbox_filter<'a>(
         Err(_) => return None,
     };
 
-    if end.cmp(&(len as u32)) == Equal {
+    if end == (len as u32) {
         end -= 1;
     }
-    debug_assert!(start.cmp(&end) != Greater, "Start is before end");
+    debug_assert!(start <= end, "Start is before end");
 
     Some((start..(end + 1)).filter_map(move |idx| {
         let grid = coords.get(idx as usize);
@@ -70,7 +70,7 @@ fn coord_binary_search<'a>(
 ) -> Result<u32, &'a str> {
     let len = coords.len() as u32;
 
-    if offset.cmp(&len) != Less {
+    if offset >= len {
         return Err("Offset greater than Vector");
     }
 

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -84,11 +84,6 @@ fn flatbuffer_generator<T: Iterator<Item=u32>>(val: T) -> Vec<u8>{
 
 #[cfg(test)]
 mod test {
-    // TO DO:
-    // case 5: when all the points are in the bbox
-    // case 5: when bbox starts in the middle of the result set and ends beyond
-    // case 6: when the bbox starts and ends in the middle of the result set
-    // case 7: when it starts before the result set and ends in between
     use super::*;
 
     #[test]
@@ -109,7 +104,19 @@ mod test {
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
         let coords = rs.coords().unwrap();
         let result = bbox_filter(coords, [0,0,1,1]).unwrap().collect::<Vec<Coord>>();
-        assert_eq!(result.len(), 3, "starts before bbox and ends between the result set");
+        assert_eq!(result.len(), 2, "starts before bbox and ends between the result set");
+
+        let buffer = flatbuffer_generator(2..4);
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [1,1,3,1]).unwrap().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 1, "starts in the bbox and ends after the result set");
+
+        let buffer = flatbuffer_generator(1..4);
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [0,1,1,1]).unwrap().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 2, "starts in the bbox and ends in the bbox");
 
         let buffer = flatbuffer_generator(5..7);
         let rs = flatbuffers::get_root::<RelevScore>(&buffer);

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -265,16 +265,22 @@ impl GridStore {
 
                     let coords_vec = get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS).unwrap();
                     let coords = match match_opts {
-                        MatchOpts { bbox: None, .. } => Box::new(coords_vec.into_iter()) as Box<Iterator<Item=Coord>>,
+                        MatchOpts { bbox: None, .. } => Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item=Coord>>),
                         MatchOpts { bbox: Some(bbox), .. } => {
                             let bbox: [u16; 4] = bbox.clone();
-                            Box::new(spatial::bbox_filter(coords_vec, bbox).unwrap()) as Box<Iterator<Item=Coord>>
+                            let res = spatial::bbox_filter(coords_vec, bbox);
+                            match res {
+                                Some(v) => Some(Box::new(v) as Box<Iterator<Item=Coord>>),
+                                None => None,
+                            }
                         },
                     };
 
-                    let slot =
-                        coords_for_rs.entry((OrderedFloat(relev), score)).or_insert_with(|| vec![]);
-                    slot.push(coords);
+                    if coords.is_some() {
+                        let slot =
+                            coords_for_rs.entry((OrderedFloat(relev), score)).or_insert_with(|| vec![]);
+                        slot.push(coords.unwrap());
+                    }
                 }
             }
 

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -195,28 +195,6 @@ impl GridStore {
         &self,
         match_key: &MatchKey,
         match_opts: &MatchOpts,
-    ) -> Result<Box<dyn Iterator<Item = MatchEntry>>, Box<Error>> {
-        match match_opts {
-            MatchOpts { bbox: None, .. } => {
-                Ok(Box::new(self.global_get_matching(match_key, &match_opts)?))
-            }
-            MatchOpts { bbox: Some(bbox), .. } => {
-                let bbox: [u16; 4] = bbox.clone();
-                let out = self.global_get_matching(match_key, &match_opts)?.filter(move |entry| {
-                    entry.grid_entry.x >= bbox[0]
-                        && entry.grid_entry.x <= bbox[2]
-                        && entry.grid_entry.y >= bbox[1]
-                        && entry.grid_entry.y <= bbox[3]
-                });
-                Ok(Box::new(out))
-            }
-        }
-    }
-
-    fn global_get_matching(
-        &self,
-        match_key: &MatchKey,
-        match_opts: &MatchOpts,
     ) -> Result<impl Iterator<Item = MatchEntry>, Box<Error>> {
         let mut db_key: Vec<u8> = Vec::new();
         match_key.write_start_to(0, &mut db_key)?;
@@ -273,7 +251,6 @@ impl GridStore {
                             Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = Coord>>)
                         }
                         MatchOpts { bbox: Some(bbox), .. } => {
-                            let bbox: [u16; 4] = bbox.clone();
                             let res = spatial::bbox_filter(coords_vec, bbox);
                             match res {
                                 Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -12,6 +12,7 @@ use rocksdb::{Direction, IteratorMode, DB};
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;
+use crate::gridstore::spatial;
 
 pub struct GridStore {
     db: DB,
@@ -196,10 +197,10 @@ impl GridStore {
         match_opts: &MatchOpts,
     ) -> Result<Box<dyn Iterator<Item = MatchEntry>>, Box<Error>> {
         match match_opts {
-            MatchOpts { bbox: None, .. } => Ok(Box::new(self.global_get_matching(match_key)?)),
+            MatchOpts { bbox: None, .. } => Ok(Box::new(self.global_get_matching(match_key, &match_opts)?)),
             MatchOpts { bbox: Some(bbox), .. } => {
                 let bbox: [u16; 4] = bbox.clone();
-                let out = self.global_get_matching(match_key)?.filter(move |entry| {
+                let out = self.global_get_matching(match_key, &match_opts)?.filter(move |entry| {
                     entry.grid_entry.x >= bbox[0]
                         && entry.grid_entry.x <= bbox[2]
                         && entry.grid_entry.y >= bbox[1]
@@ -213,9 +214,12 @@ impl GridStore {
     fn global_get_matching(
         &self,
         match_key: &MatchKey,
+        match_opts: &MatchOpts,
     ) -> Result<impl Iterator<Item = MatchEntry>, Box<Error>> {
         let mut db_key: Vec<u8> = Vec::new();
         match_key.write_start_to(0, &mut db_key)?;
+
+        let match_opts = match_opts.clone();
 
         let db_iter = self
             .db
@@ -259,13 +263,18 @@ impl GridStore {
                     // mask for the least significant four bits
                     let score = relev_score & 15;
 
-                    let coords =
-                        get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS)
-                            .unwrap();
+                    let coords_vec = get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS).unwrap();
+                    let coords = match match_opts {
+                        MatchOpts { bbox: None, .. } => Box::new(coords_vec.into_iter()) as Box<Iterator<Item=Coord>>,
+                        MatchOpts { bbox: Some(bbox), .. } => {
+                            let bbox: [u16; 4] = bbox.clone();
+                            Box::new(spatial::bbox_filter(coords_vec, bbox)) as Box<Iterator<Item=Coord>>
+                        },
+                    };
 
                     let slot =
                         coords_for_rs.entry((OrderedFloat(relev), score)).or_insert_with(|| vec![]);
-                    slot.push(coords.into_iter());
+                    slot.push(coords);
                 }
             }
 

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -268,7 +268,7 @@ impl GridStore {
                         MatchOpts { bbox: None, .. } => Box::new(coords_vec.into_iter()) as Box<Iterator<Item=Coord>>,
                         MatchOpts { bbox: Some(bbox), .. } => {
                             let bbox: [u16; 4] = bbox.clone();
-                            Box::new(spatial::bbox_filter(coords_vec, bbox)) as Box<Iterator<Item=Coord>>
+                            Box::new(spatial::bbox_filter(coords_vec, bbox).unwrap()) as Box<Iterator<Item=Coord>>
                         },
                     };
 

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -197,7 +197,9 @@ impl GridStore {
         match_opts: &MatchOpts,
     ) -> Result<Box<dyn Iterator<Item = MatchEntry>>, Box<Error>> {
         match match_opts {
-            MatchOpts { bbox: None, .. } => Ok(Box::new(self.global_get_matching(match_key, &match_opts)?)),
+            MatchOpts { bbox: None, .. } => {
+                Ok(Box::new(self.global_get_matching(match_key, &match_opts)?))
+            }
             MatchOpts { bbox: Some(bbox), .. } => {
                 let bbox: [u16; 4] = bbox.clone();
                 let out = self.global_get_matching(match_key, &match_opts)?.filter(move |entry| {
@@ -263,22 +265,27 @@ impl GridStore {
                     // mask for the least significant four bits
                     let score = relev_score & 15;
 
-                    let coords_vec = get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS).unwrap();
+                    let coords_vec =
+                        get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS)
+                            .unwrap();
                     let coords = match match_opts {
-                        MatchOpts { bbox: None, .. } => Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item=Coord>>),
+                        MatchOpts { bbox: None, .. } => {
+                            Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = Coord>>)
+                        }
                         MatchOpts { bbox: Some(bbox), .. } => {
                             let bbox: [u16; 4] = bbox.clone();
                             let res = spatial::bbox_filter(coords_vec, bbox);
                             match res {
-                                Some(v) => Some(Box::new(v) as Box<Iterator<Item=Coord>>),
+                                Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
                                 None => None,
                             }
-                        },
+                        }
                     };
 
                     if coords.is_some() {
-                        let slot =
-                            coords_for_rs.entry((OrderedFloat(relev), score)).or_insert_with(|| vec![]);
+                        let slot = coords_for_rs
+                            .entry((OrderedFloat(relev), score))
+                            .or_insert_with(|| vec![]);
                         slot.push(coords.unwrap());
                     }
                 }

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -251,8 +251,7 @@ impl GridStore {
                             Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = Coord>>)
                         }
                         MatchOpts { bbox: Some(bbox), .. } => {
-                            let res = spatial::bbox_filter(coords_vec, bbox);
-                            match res {
+                            match spatial::bbox_filter(coords_vec, bbox) {
                                 Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
                                 None => None,
                             }


### PR DESCRIPTION
## Context 
When the user provides a bounding box or a proximity parameter, we need a way to search over the grids and return those that fall within the bbox and near the proximity point. This PR adds a binary search over the grids and integrates it with the worked that moved as a part of #1 

## Summary of changes 
- Adds `rust-src/src/gridstore/spatial.rs` - core logic for binary search over grids + tests 
- Modifies `rust-src/src/gridstore/store.rs` - integrates bbox_filter with current logic

## Next actions: 
- [x] Wire up bbox_filter with `store.rs`
- [x] Write remaining tests outlined here - https://github.com/mapbox/carmen-core/compare/spatialsearch?expand=1#diff-323bb3f1330715ac0db81b04e910cf1bR38
- [ ] Review
- [ ] Merge 

## Maybe now, maybe follow up

- [ ] Avoid deinterleaving morton order twice
- [ ] Optimize binary search for min/max use case.
- [ ] Hoist bbox interator up out of the generic get_matching

cc @apendleton @Nmargolis @miccolis 