### PR TITLE
Implement proximity filtering and proximity bbox filtering

### DIFF
--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -130,6 +130,7 @@ fn matching_test() {
                 GridEntry { id: i + 3, x: ((2 * i) + 1) as u16, y: 1, relev: 1., score: 7, source_phrase_hash: 0 },
             ];
             i += 4;
+
             builder.insert(&key, &entries).expect("Unable to insert record");
         }
     }

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -130,7 +130,6 @@ fn matching_test() {
                 GridEntry { id: i + 3, x: ((2 * i) + 1) as u16, y: 1, relev: 1., score: 7, source_phrase_hash: 0 },
             ];
             i += 4;
-
             builder.insert(&key, &entries).expect("Unable to insert record");
         }
     }
@@ -297,4 +296,28 @@ fn matching_test() {
         .unwrap()
         .collect();
     assert_eq!(records.len(), 0, "no matching recods in bbox");
+
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
+    let records: Vec<_> = reader
+        .get_matching(
+            &search_key,
+            &MatchOpts { bbox: Some([10, 0, 41, 2]), proximity: Some([26, 1]) },
+        )
+        .unwrap()
+        .collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
+    assert_eq!(
+        records,
+        [
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 26, y: 1, id: 14, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 15, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 13, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 24, y: 1, id: 12, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 23, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 21, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 42, y: 1, id: 22, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 40, y: 1, id: 20, source_phrase_hash: 0 }, matches_language: false }
+        ]
+    );
 }

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -300,6 +300,31 @@ fn matching_test() {
     let search_key =
         MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
     let records: Vec<_> = reader
+        .get_matching(&search_key, &MatchOpts { bbox: None, proximity: Some([26, 1]) })
+        .unwrap()
+        .collect();
+    #[cfg_attr(rustfmt, rustfmt::skip)]
+    assert_eq!(
+        records,
+        [
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 26, y: 1, id: 14, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 15, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 25, y: 1, id: 13, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 24, y: 1, id: 12, source_phrase_hash: 0 }, matches_language: true },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 31, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 57, y: 1, id: 29, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 58, y: 1, id: 30, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 23, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 21, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 42, y: 1, id: 22, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 56, y: 1, id: 28, source_phrase_hash: 0 }, matches_language: false },
+            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 40, y: 1, id: 20, source_phrase_hash: 0 }, matches_language: false }
+        ]
+    );
+
+    let search_key =
+        MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 };
+    let records: Vec<_> = reader
         .get_matching(
             &search_key,
             &MatchOpts { bbox: Some([10, 0, 41, 2]), proximity: Some([26, 1]) },

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -342,7 +342,6 @@ fn matching_test() {
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 24, y: 1, id: 12, source_phrase_hash: 0 }, matches_language: true },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 23, source_phrase_hash: 0 }, matches_language: false },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 41, y: 1, id: 21, source_phrase_hash: 0 }, matches_language: false },
-            MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 7, x: 42, y: 1, id: 22, source_phrase_hash: 0 }, matches_language: false },
             MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 40, y: 1, id: 20, source_phrase_hash: 0 }, matches_language: false }
         ]
     );

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -74,8 +74,8 @@ pub fn bbox_filter<'a>(
 
 /// Generate an Iterator over a Coord Vector given a proximity point
 ///
-/// Returns [`Some(Iterator<>`] which is a Coord Vector morton order range that overlaps with a bounding box and is ordered by the z-order distance from the proximity point
-/// [`None`] if the bounding box does not overlap with the morton order range
+/// Returns [`Some(Iterator<>`] which is a Coord Vector morton order range ordered by the z-order distance from the proximity point
+/// [`None`] if the Coord Vector is empty
 pub fn proximity<'a>(
     coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
     proximity: [u16; 2],
@@ -105,8 +105,8 @@ pub fn proximity<'a>(
 
 /// Generate an Iterator for a bounding box and proximity point over a Coord Vector
 ///
-/// Returns [`Some(Iterator<>`] which is a Coord Vector morton order range ordered by the z-order distance from the proximity point
-/// [`None`] if the Coord Vector is empty
+/// Returns [`Some(Iterator<>`] which is a Coord Vector morton order range that overlaps with a bounding box and is ordered by the z-order distance from the proximity point
+/// [`None`] if the bounding box does not overlap with the morton order range
 pub fn bbox_proximity_filter<'a>(
     coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
     bbox: [u16; 4],
@@ -125,7 +125,7 @@ pub fn bbox_proximity_filter<'a>(
 
     let getter = move |i| coords.get(i as usize);
     let head = Box::new((range.0..prox_mid).rev().map(getter)) as Box<Iterator<Item = Coord>>;
-    let tail = Box::new((prox_mid..range.1 + 1).map(getter)) as Box<Iterator<Item = Coord>>;
+    let tail = Box::new((prox_mid..=range.1).map(getter)) as Box<Iterator<Item = Coord>>;
     let coord_sets = vec![head, tail].into_iter().kmerge_by(move |a, b| {
         let d1 = (a.coord() as i64 - prox_pt) as i64;
         let d2 = (b.coord() as i64 - prox_pt) as i64;

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -9,10 +9,10 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 /// Returns [`Some(Iterator<>`] if the Coord Vector morton order range overlaps with the bouding box,
 /// [`None`] otherwise. May return an Iterator that yields no results if the morton order overlaps
 /// but the actual elements are not in the bounding box.
-pub fn bbox_filter<'a>(
+pub fn bbox_range<'a>(
     coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
     bbox: [u16; 4],
-) -> Option<impl Iterator<Item = Coord<'a>>> {
+) -> Option<(u32, u32)> {
     let min = interleave_morton(bbox[0], bbox[1]);
     let max = interleave_morton(bbox[2], bbox[3]);
     debug_assert!(min <= max, "Invalid bounding box");
@@ -45,8 +45,20 @@ pub fn bbox_filter<'a>(
         end -= 1;
     }
     debug_assert!(start <= end, "Start is before end");
+    Some((start, end))
+}
 
-    Some((start..(end + 1)).filter_map(move |idx| {
+pub fn bbox_filter<'a>(
+    coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
+    bbox: [u16; 4],
+) -> Option<impl Iterator<Item = Coord<'a>>> {
+    let len = coords.len();
+    if len == 0 {
+        return None;
+    }
+
+    let range = bbox_range(coords, bbox)?;
+    Some((range.0..(range.1 + 1)).filter_map(move |idx| {
         let grid = coords.get(idx as usize);
         let (x, y) = deinterleave_morton(grid.coord()); // TODO capture this so we don't have to do it again.
         if x >= bbox[0] && x <= bbox[2] && y >= bbox[1] && y <= bbox[3] {
@@ -83,6 +95,33 @@ pub fn proximity_filter<'a>(
     Some(coord_sets)
 }
 
+pub fn bbox_proximity_filter<'a>(
+    coords: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>,
+    bbox: [u16; 4],
+    proximity: (u16, u16),
+) -> Option<impl Iterator<Item = Coord<'a>>> {
+    let range = bbox_range(coords, bbox)?;
+    let prox_pt = interleave_morton(proximity.0, proximity.1) as i64;
+    if coords.len() == 0 {
+        return None;
+    }
+
+    let prox_mid = match coord_binary_search(&coords, prox_pt as u32, 0) {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+
+    let getter = move |i| coords.get(i as usize);
+    let head = Box::new((range.0..prox_mid).rev().map(getter)) as Box<Iterator<Item = Coord>>;
+    let tail = Box::new((prox_mid..range.1 + 1).map(getter)) as Box<Iterator<Item = Coord>>;
+    let coord_sets = vec![head, tail].into_iter().kmerge_by(move |a, b| {
+        let d1 = (a.coord() as i64 - prox_pt) as i64;
+        let d2 = (b.coord() as i64 - prox_pt) as i64;
+        d1.abs().cmp(&d2.abs()) == Less
+    });
+
+    Some(coord_sets)
+}
 /// Binary search this FlatBuffers Coord Vector
 ///
 /// Derived from binary_search_by in core/slice/mod.rs except this expects descending order.
@@ -267,6 +306,23 @@ mod test {
             vec![7, 6, 8, 13, 1, 21, 24],
             result,
             "sparse result set sorted by z-order in the middle of the result set"
+        );
+    }
+
+    #[test]
+    fn bbox_proximity_search() {
+        let buffer = flatbuffer_generator((1..10).rev()); // [9,8,7,6,5,4,3,2,1]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        // bbox is from 1-7; proximity is 4
+        let result = bbox_proximity_filter(coords, [1, 0, 3, 1], (2, 0))
+            .unwrap()
+            .map(|x| x.coord())
+            .collect::<Vec<u32>>();
+        assert_eq!(
+            vec![4, 3, 5, 6, 2, 1, 7],
+            result,
+            "bbox within the range of coordinates; proximity point within the result set"
         );
     }
 

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -249,11 +249,23 @@ impl GridStore {
                         get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS)
                             .unwrap();
                     let coords = match match_opts {
-                        MatchOpts { bbox: None, .. } => {
+                        MatchOpts { bbox: None, proximity: None } => {
                             Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = Coord>>)
                         }
-                        MatchOpts { bbox: Some(bbox), .. } => {
+                        MatchOpts { bbox: Some(bbox), proximity: None } => {
                             match spatial::bbox_filter(coords_vec, bbox) {
+                                Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
+                                None => None,
+                            }
+                        }
+                        MatchOpts { bbox: None, proximity: Some(prox_pt) } => {
+                            match spatial::proximity(coords_vec, prox_pt) {
+                                Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
+                                None => None,
+                            }
+                        }
+                        MatchOpts { bbox: Some(bbox), proximity: Some(prox_pt) } => {
+                            match spatial::bbox_proximity_filter(coords_vec, bbox, prox_pt) {
                                 Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
                                 None => None,
                             }


### PR DESCRIPTION
When the user provides a proximity parameter, we need a way to search over the grids and return those that fall near the proximity point. When a user provides both - a proximity point and a bbox filter we should return points within the bbox and near the proximity point provided. This PR adds the ability to sort the grids based on the proximity point and also provides the option to filter by bbox and sort by proximity point by providing both parameters. 

## Changes: 
- Adds `proximity()` function to `spatial.rs`
- Adds `bbox_proximity_filter()` function to `spatial.rs`
- Adds unit tests for both 

## Next actions: 
- [x] Write more unit tests 
- [x] Review 
- [x] Integrate with `store.rs` 


cc @apendleton, @miccolis, @Nmargolis 