### PR TITLE
Javascript wrappers

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -9,9 +9,235 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.47.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "carmen-core"
+version = "0.1.0"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)",
+ "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.12.2 (git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cast"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clang-sys"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cslice"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "env_logger"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "0.5.0"
+source = "git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6#c330fcc941aacbe23e076589c5afbdb6504ceba6"
+dependencies = [
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "gcc"
@@ -19,14 +245,87 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "humantime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libc"
+version = "0.2.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "5.18.3"
+source = "git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e#f6a9d278262f090790578dbf435e591748c4622e"
+dependencies = [
+ "bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "morton"
+version = "0.2.0"
+source = "git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e#d892e8f2759aa2de29629232946db47924f1802e"
 
 [[package]]
 name = "neon"
@@ -54,11 +353,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "neon-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-runtime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "node-carmen-core"
 version = "0.1.0"
 dependencies = [
+ "carmen-core 0.1.0",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ordered-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -74,12 +490,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.12.2"
+source = "git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e#f6a9d278262f090790578dbf435e591748c4622e"
+dependencies = [
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "librocksdb-sys 5.18.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e)",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
@@ -95,6 +550,71 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.15.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,23 +628,160 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df683a55b54b41d5ea8ebfaebb5aa7e6b84e3f3006a78f010dadc9ca88469260"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
+"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
+"checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
+"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)" = "<none>"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
+"checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
+"checksum librocksdb-sys 5.18.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e)" = "<none>"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)" = "<none>"
 "checksum neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2e4dcd1e15c5944d89d283ec7c3b1b4ef83b5d2227b3b5d91d33224a45c7a3"
 "checksum neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "870c8f0b18ce83d8af6d95b9b723678aef55c047f29e09ac3e3d10ceecf57fd0"
 "checksum neon-runtime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff1178addfa03e060fc79e795c21170823e69f0229b0b13a4a2585190ef8fa76"
+"checksum neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "426deefc3718e89c8ee4528db5a8e71776f9326a387629b83b705ee2c1dae198"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+"checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
+"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
+"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
+"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
+"checksum rocksdb 0.12.2 (git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e)" = "<none>"
+"checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
+"checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
+"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,3 +15,5 @@ neon-build = "0.2.0"
 
 [dependencies]
 neon = "0.2.0"
+neon-serde = "0.1.1"
+carmen-core = { path = "../" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -5,31 +5,65 @@ extern crate carmen_core;
 use neon::prelude::*;
 use carmen_core::gridstore::{GridStoreBuilder, GridEntry, GridKey};
 
-trait CheckArgument {
-    fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<V>;
+trait take {
+    fn take<V: Value>(&mut self, i: i32) -> JsResult<V>;
 }
+pub fn take(&mut self) -> Option<T> {
+       mem::replace(self, None)
+   }
+
+impl
 
 declare_types! {
-    pub class JsGridStoreBuilder as JsGridStoreBuilder for Option<GridStoreBuilder> {
+    pub class JsGridStoreBuilder as JsGridStoreBuilder for GridStoreBuilder {
         init(mut cx) {
             let filename = cx
                 .argument::<JsString>(0)
                 ?.value();
             match GridStoreBuilder::new(filename) {
-                Ok(s) => Ok(Some(s)),
+                Ok(s) => Ok(s),
                 Err(e) => cx.throw_type_error(e.description())
             }
         }
-        method insert(cx) {
+
+        method insert(mut cx) {
             let grid_key = cx.argument::<JsValue>(0)?;
             let grid_entry = cx.argument::<JsValue>(1)?;
-            let mut this: Handle<JsGridStoreBuilder> = cx.argument.this(cx);
-            let entry: Vec<GridEntry> = neon_serde::from_value(&mut cx, grid_entry)?;
-            let key: Vec<GridKey> = neon_serde::from_value(&mut cx, grid_key)?;
+            let values: Vec<GridEntry> = neon_serde::from_value(&mut cx, grid_entry)?;
+            let key: GridKey = neon_serde::from_value(&mut cx, grid_key)?;
+            let mut this = cx.this();
 
+            // lock falls out of scope at the end of this block
+            // in order to be able to borrow `cx` for the error block we assign it to a variable
+            let insert = {
+                let lock = cx.lock();
+                let mut gridstore = this.borrow_mut(&lock);
+                gridstore.insert(&key, &values)
+            };
+
+            match insert {
+                Ok(_) => Ok(JsUndefined::new().upcast()),
+                Err(e) => cx.throw_type_error(e.description())
+            }
+        }
+
+        method finish(mut cx) {
+            let this = cx.this();
+
+            let finish = {
+                let lock = cx.lock();
+                let gridstore = this.borrow(&lock);
+                gridstore.take().finish()
+            };
+
+            match finish {
+                Ok(_) => Ok(JsUndefined::new().upcast()),
+                Err(e) => cx.throw_type_error(e.description())
+            }
         }
     }
 }
+
 
 register_module!(mut m, {
     m.export_class::<JsGridStoreBuilder>("JsGridStoreBuilder")

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,10 +2,48 @@
 extern crate neon;
 extern crate carmen_core;
 extern crate neon_serde;
-use carmen_core::gridstore::{GridEntry, GridKey, GridStore, GridStoreBuilder};
-use neon_serde::errors::Result as LibResult;
+use carmen_core::gridstore::coalesce;
+use carmen_core::gridstore::PhrasematchSubquery;
+use carmen_core::gridstore::{
+    CoalesceContext, GridEntry, GridKey, GridStore, GridStoreBuilder, MatchOpts,
+};
+
 use neon::prelude::*;
+use neon_serde::errors::Result as LibResult;
 use std::error::Error;
+use std::sync::Arc;
+
+type ArcGridStore = Arc<GridStore>;
+
+struct CoalesceTask {
+    argument: (Vec<PhrasematchSubquery<ArcGridStore>>, MatchOpts),
+}
+
+impl Task for CoalesceTask {
+    type Output = Vec<CoalesceContext>;
+    type Error = String;
+    type JsEvent = JsArray;
+
+    fn perform(&self) -> Result<Vec<CoalesceContext>, String> {
+        coalesce(&self.argument.0, &self.argument.1).map_err(|err| err.to_string())
+    }
+
+    fn complete<'a>(
+        self,
+        mut cx: TaskContext<'a>,
+        result: Result<Vec<CoalesceContext>, String>,
+    ) -> JsResult<JsArray> {
+        let converted_result = {
+            match &result {
+                Ok(r) => r,
+                Err(s) => return cx.throw_error(s),
+            }
+        };
+        Ok(neon_serde::to_value(&mut cx, converted_result)?
+            .downcast::<JsArray>()
+            .or_throw(&mut cx)?)
+    }
+}
 
 declare_types! {
     pub class JsGridStoreBuilder as JsGridStoreBuilder for Option<GridStoreBuilder> {
@@ -85,11 +123,11 @@ declare_types! {
         }
     }
 
-    pub class JsGridStore as JsGridStore for GridStore {
+    pub class JsGridStore as JsGridStore for ArcGridStore {
         init(mut cx) {
             let filename = cx.argument::<JsString>(0)?.value();
             match GridStore::new(filename) {
-                Ok(s) => Ok(s),
+                Ok(s) => Ok(Arc::new(s)),
                 Err(e) => cx.throw_type_error(e.description())
             }
         }
@@ -98,35 +136,72 @@ declare_types! {
 
 fn langarray_to_langset<'j, C>(cx: &mut C, lang_array: Handle<'j, JsArray>) -> LibResult<u128>
 where
-    C: Context<'j>
+    C: Context<'j>,
 {
     let mut out = 0u128;
     for i in 0..lang_array.len() {
-        out = out | (1 << lang_array.get(cx, i)?.downcast::<JsNumber>().or_throw(cx)?.value() as usize);
+        out = out
+            | (1 << lang_array.get(cx, i)?.downcast::<JsNumber>().or_throw(cx)?.value() as usize);
     }
     Ok(out)
 }
 
-pub fn coalesce(mut cx, FunctionContext) -> JsResult<JsUndefined> {
+pub fn js_coalesce(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let js_phrase_subq = { cx.argument::<JsArray>(0)? };
+    let js_match_ops = { cx.argument::<JsValue>(1)? };
+    let phrase_subq: Vec<PhrasematchSubquery<ArcGridStore>> =
+        deserialize_phrasesubq(&mut cx, js_phrase_subq)?;
+    let match_opts: MatchOpts = neon_serde::from_value(&mut cx, js_match_ops)?;
+    let cb = cx.argument::<JsFunction>(2)?;
 
+    let task = CoalesceTask { argument: (phrase_subq, match_opts) };
+    task.schedule(cb);
+
+    Ok(cx.undefined())
 }
 
-/*
-fn langfield_to_langarray(&mut cx: FunctionContext, langset: u128) -> JsResult<JsArray> {
-    let lang_array: Handle<JsArray> = JsArray::new(&mut cx, 0u32);
-    let mut idx = 0u32;
-    for i in 0..128 {
-        if (langset & (1 << i)) != 0 {
-            let js_number = cx.number(i as f64);
-            lang_array.set(cx, idx, js_number);
-            idx += 1;
-        }
+fn deserialize_phrasesubq<'j, C>(
+    cx: &mut C,
+    js_phrase_subq_array: Handle<'j, JsArray>,
+) -> LibResult<Vec<PhrasematchSubquery<ArcGridStore>>>
+where
+    C: Context<'j>,
+{
+    let mut phrasematches: Vec<PhrasematchSubquery<ArcGridStore>> =
+        Vec::with_capacity(js_phrase_subq_array.len() as usize);
+    for i in 0..js_phrase_subq_array.len() {
+        let js_phrasematch =
+            js_phrase_subq_array.get(cx, i)?.downcast::<JsObject>().or_throw(cx)?;
+        let js_gridstore =
+            js_phrasematch.get(cx, "store")?.downcast::<JsGridStore>().or_throw(cx)?;
+        let gridstore = {
+            let guard = cx.lock();
+            // shallow clone of the Arc
+            let gridstore_clone = js_gridstore.borrow(&guard).clone();
+            gridstore_clone
+        };
+        let weight = js_phrasematch.get(cx, "weight")?;
+        let match_key = js_phrasematch.get(cx, "match_key")?;
+        let idx = js_phrasematch.get(cx, "idx")?;
+        let zoom = js_phrasematch.get(cx, "zoom")?;
+        let mask = js_phrasematch.get(cx, "mask")?;
+
+        let subq = PhrasematchSubquery {
+            store: gridstore,
+            weight: neon_serde::from_value(cx, weight)?,
+            match_key: neon_serde::from_value(cx, match_key)?,
+            idx: neon_serde::from_value(cx, idx)?,
+            zoom: neon_serde::from_value(cx, zoom)?,
+            mask: neon_serde::from_value(cx, mask)?,
+        };
+        phrasematches.push(subq);
     }
-    Ok(lang_array)
+    Ok(phrasematches)
 }
-*/
+
 register_module!(mut m, {
     m.export_class::<JsGridStoreBuilder>("JsGridStoreBuilder")?;
     m.export_class::<JsGridStore>("JsGridStore")?;
+    m.export_function("coalesce", js_coalesce)?;
     Ok(())
 });

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,4 +1,36 @@
 #[macro_use]
 extern crate neon;
+extern crate neon_serde;
+extern crate carmen_core;
+use neon::prelude::*;
+use carmen_core::gridstore::{GridStoreBuilder, GridEntry, GridKey};
 
-register_module!(mut _m, { Ok(()) });
+trait CheckArgument {
+    fn check_argument<V: Value>(&mut self, i: i32) -> JsResult<V>;
+}
+
+declare_types! {
+    pub class JsGridStoreBuilder as JsGridStoreBuilder for Option<GridStoreBuilder> {
+        init(mut cx) {
+            let filename = cx
+                .argument::<JsString>(0)
+                ?.value();
+            match GridStoreBuilder::new(filename) {
+                Ok(s) => Ok(Some(s)),
+                Err(e) => cx.throw_type_error(e.description())
+            }
+        }
+        method insert(cx) {
+            let grid_key = cx.argument::<JsValue>(0)?;
+            let grid_entry = cx.argument::<JsValue>(1)?;
+            let mut this: Handle<JsGridStoreBuilder> = cx.argument.this(cx);
+            let entry: Vec<GridEntry> = neon_serde::from_value(&mut cx, grid_entry)?;
+            let key: Vec<GridKey> = neon_serde::from_value(&mut cx, grid_key)?;
+
+        }
+    }
+}
+
+register_module!(mut m, {
+    m.export_class::<JsGridStoreBuilder>("JsGridStoreBuilder")
+});

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -25,7 +25,7 @@ impl Task for CoalesceTask {
     type JsEvent = JsArray;
 
     fn perform(&self) -> Result<Vec<CoalesceContext>, String> {
-        coalesce(&self.argument.0, &self.argument.1).map_err(|err| err.to_string())
+        coalesce(self.argument.0.clone(), &self.argument.1).map_err(|err| err.to_string())
     }
 
     fn complete<'a>(

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,16 +2,15 @@
 extern crate neon;
 extern crate carmen_core;
 extern crate neon_serde;
-use carmen_core::gridstore::{GridEntry, GridKey, GridStoreBuilder};
+use carmen_core::gridstore::{GridEntry, GridKey, GridStore, GridStoreBuilder};
+use neon_serde::errors::Result as LibResult;
 use neon::prelude::*;
 use std::error::Error;
 
 declare_types! {
     pub class JsGridStoreBuilder as JsGridStoreBuilder for Option<GridStoreBuilder> {
         init(mut cx) {
-            let filename = cx
-                .argument::<JsString>(0)
-                ?.value();
+            let filename = cx.argument::<JsString>(0)?.value();
             match GridStoreBuilder::new(filename) {
                 Ok(s) => Ok(Some(s)),
                 Err(e) => cx.throw_type_error(e.description())
@@ -19,10 +18,26 @@ declare_types! {
         }
 
         method insert(mut cx) {
-            let grid_key = cx.argument::<JsValue>(0)?;
+            let grid_key = cx.argument::<JsObject>(0)?;
             let grid_entry = cx.argument::<JsValue>(1)?;
             let values: Vec<GridEntry> = neon_serde::from_value(&mut cx, grid_entry)?;
-            let key: GridKey = neon_serde::from_value(&mut cx, grid_key)?;
+            let js_phrase_id = {
+                grid_key.get(&mut cx, "phrase_id")?
+            };
+            let phrase_id: u32 = {
+                js_phrase_id.downcast::<JsNumber>().or_throw(&mut cx)?.value() as u32
+            };
+            let js_lang_set = {
+                grid_key.get(&mut cx, "lang_set")?
+            };
+
+            let js_array_lang = {
+                js_lang_set.downcast::<JsArray>().or_throw(&mut cx)?
+            };
+
+            let lang_set: u128 = langarray_to_langset(&mut cx, js_array_lang)?;
+
+            let key = GridKey { phrase_id, lang_set };
             let mut this = cx.this();
 
             // lock falls out of scope at the end of this block
@@ -69,6 +84,49 @@ declare_types! {
             }
         }
     }
+
+    pub class JsGridStore as JsGridStore for GridStore {
+        init(mut cx) {
+            let filename = cx.argument::<JsString>(0)?.value();
+            match GridStore::new(filename) {
+                Ok(s) => Ok(s),
+                Err(e) => cx.throw_type_error(e.description())
+            }
+        }
+    }
 }
 
-register_module!(mut m, { m.export_class::<JsGridStoreBuilder>("JsGridStoreBuilder") });
+fn langarray_to_langset<'j, C>(cx: &mut C, lang_array: Handle<'j, JsArray>) -> LibResult<u128>
+where
+    C: Context<'j>
+{
+    let mut out = 0u128;
+    for i in 0..lang_array.len() {
+        out = out | (1 << lang_array.get(cx, i)?.downcast::<JsNumber>().or_throw(cx)?.value() as usize);
+    }
+    Ok(out)
+}
+
+pub fn coalesce(mut cx, FunctionContext) -> JsResult<JsUndefined> {
+
+}
+
+/*
+fn langfield_to_langarray(&mut cx: FunctionContext, langset: u128) -> JsResult<JsArray> {
+    let lang_array: Handle<JsArray> = JsArray::new(&mut cx, 0u32);
+    let mut idx = 0u32;
+    for i in 0..128 {
+        if (langset & (1 << i)) != 0 {
+            let js_number = cx.number(i as f64);
+            lang_array.set(cx, idx, js_number);
+            idx += 1;
+        }
+    }
+    Ok(lang_array)
+}
+*/
+register_module!(mut m, {
+    m.export_class::<JsGridStoreBuilder>("JsGridStoreBuilder")?;
+    m.export_class::<JsGridStore>("JsGridStore")?;
+    Ok(())
+});

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -1,7 +1,7 @@
+use std::borrow::Borrow;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::borrow::Borrow;
 
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -186,7 +186,8 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
         // TODO: check if zooms are equivalent here, and only call adjust_to_zoom if they arent?
         // That way we could avoid a function call and creating a cloned object in the common case where the zooms are the same
         let adjusted_match_opts = match_opts.adjust_to_zoom(subquery.zoom);
-        let grids = subquery.store.borrow().get_matching(&subquery.match_key, &adjusted_match_opts)?;
+        let grids =
+            subquery.store.borrow().get_matching(&subquery.match_key, &adjusted_match_opts)?;
 
         // TODO: limit how many grids we consume
         for grid in grids {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
 use std::borrow::Borrow;
+use std::error::Error;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -80,13 +80,13 @@ impl MatchKey {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Proximity {
     pub point: [u16; 2],
     pub radius: f64,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct MatchOpts {
     pub bbox: Option<[u16; 4]>,
     pub proximity: Option<Proximity>,
@@ -343,8 +343,8 @@ pub struct CoalesceContext {
 }
 
 #[derive(Debug, Clone)]
-pub struct PhrasematchSubquery<'a> {
-    pub store: &'a GridStore,
+pub struct PhrasematchSubquery<T: AsRef<GridStore> + Clone> {
+    pub store: T,
     pub weight: f32,
     pub match_key: MatchKey,
     pub idx: u16,

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::borrow::Borrow;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
@@ -343,7 +344,7 @@ pub struct CoalesceContext {
 }
 
 #[derive(Debug, Clone)]
-pub struct PhrasematchSubquery<T: AsRef<GridStore> + Clone> {
+pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
     pub store: T,
     pub weight: f32,
     pub match_key: MatchKey,

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -419,7 +419,7 @@ mod tests {
             zoom: 14,
             mask: 1 << 0,
         };
-        let stack = vec![&subquery];
+        let stack = vec![subquery];
         let match_opts = MatchOpts {
             zoom: 14,
             proximity: Some(Proximity { point: [110, 115], radius: 200. }),

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -419,7 +419,7 @@ mod tests {
             zoom: 14,
             mask: 1 << 0,
         };
-        let stack = vec![subquery];
+        let stack = vec![&subquery];
         let match_opts = MatchOpts {
             zoom: 14,
             proximity: Some(Proximity { point: [110, 115], radius: 200. }),
@@ -471,7 +471,7 @@ mod tests {
             zoom: 14,
             mask: 1 << 0,
         };
-        let stack = vec![subquery];
+        let stack = vec![subquery.clone()];
         let match_opts = MatchOpts {
             zoom: 14,
             proximity: Some(Proximity { point: [2, 2], radius: 400. }),
@@ -482,7 +482,7 @@ mod tests {
             result.iter().map(|context| context.entries[0].grid_entry.id).collect();
         assert_eq!(result_ids, [1, 2, 4, 3], "Results with the same relev and score should be ordered by distance");
 
-        let result_distances: Vec<f64> = 
+        let result_distances: Vec<f64> =
             result.iter().map(|context| round(context.entries[0].distance, 2)).collect();
         assert_eq!(result_distances, [0.00, 2.00, 2.00, 2.83], "Results with the same relev and score should be ordered by distance");
     }
@@ -585,7 +585,7 @@ mod tests {
                 mask: 1 << 1,
             },
         ];
-        
+
         let match_opts = MatchOpts {
             zoom: 14,
             proximity: Some(Proximity { point: [2, 2], radius: 1. }),
@@ -793,7 +793,7 @@ mod tests {
                 }
             }],
         }, "With bbox - result has expected properties");
-    
+
         // Test with bbox and proximity
         let match_opts = MatchOpts {
             zoom: 6,

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const addon = require('../native');
+const tape = require('tape');
+const tmp = require('tmp');
+
+tape('JsGridStoreBuilder init', (t) => {
+    const tmpDir = tmp.dirSync();
+    t.throws(() => new addon.JsGridStoreBuilder(), 'not enough arguments');
+    const store = new addon.JsGridStoreBuilder(tmpDir.name);
+    t.ok(store);
+    t.end();
+});
+
+tape('JsGridStoreBuilder insert', (t) => {
+    const tmpDir = tmp.dirSync();
+    const store = new addon.JsGridStoreBuilder(tmpDir.name);
+    t.throws(() => grid.insert(), 'not enough arguments');
+    const id = {
+        phrase_id: 1,
+        lang_set: [0, 1, 2, 3]
+    };
+    const entries = [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }];
+    store.insert(id, entries);
+    t.ok(store);
+    t.end();
+});


### PR DESCRIPTION
Per https://github.com/mapbox/carmen-core/issues/5, we need a way to read from and write to the GridStore; we also need a way to call `coalesce` in carmen for spatialmatch operations. This PR provides a node wrappers for the reader and writer as well as coalesce which can run async. 

## Api Design 
**(these haven't been fleshed out completely and will be added properly with the next PR that adds the tests)**
1. `JsGridStoreBuilder`: 
Description: Creates a new GridStoreBuilder with the filename provided.
Parameters: 
`filename`: String

2. `insert()`: 
Description: Inserting GridKey and associated GridEntry to the gridstore.
Parameters:
gridkey: Object eg. `{ phrase_id: 1,  lang_set: [0, 1, 2, 3]};`
gridentry: Array eg. `[{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }];`

3. `finish()`
Description: Writes the data to disk.
Parameters: n/a

4. `js_coalesce`: 
Description: Javascript wrapper for coalesce which runs asynchronously. 
Parameters: 
phrasematch subqueries: Array of phrasematch subqueries 
match options: Object of bbox and proximity options 

## Next actions: 
Note: This PR builds with cargo and neon build and passes all the tests, but requires more testing on the javascript side. This will be added in the following PR which will also add more documentation about the api design and docs for the js-wrappers. 
- [ ] Review 
- [ ] Merge
Capturing next actions for the follow up PR: 
- [ ] Tests for the reader
- [ ] Port tests from carmen-cache / write js tests for coalesce 
- [ ] Write an `API.md` for the interface

cc @apendleton @miccolis @Nmargolis 