### PR TITLE
Failure crate + Rust 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ name = "carmen-core"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)",
@@ -213,6 +214,18 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -596,6 +609,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +764,7 @@ dependencies = [
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)" = "<none>"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
@@ -789,6 +814,7 @@ dependencies = [
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.8"
 flatbuffers = { git = "https://github.com/TethysSvensson/flatbuffers.git", rev = "c330fcc941aacbe23e076589c5afbdb6504ceba6" }
 byteorder = "1.3"
 ordered-float = "1.0"
+failure = "0.1.5"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -104,6 +104,7 @@ name = "carmen-core"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)",
@@ -229,6 +230,18 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -369,6 +382,7 @@ name = "node-carmen-core"
 version = "0.1.0"
 dependencies = [
  "carmen-core 0.1.0",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -588,6 +602,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +748,7 @@ dependencies = [
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum flatbuffers 0.5.0 (git+https://github.com/TethysSvensson/flatbuffers.git?rev=c330fcc941aacbe23e076589c5afbdb6504ceba6)" = "<none>"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
@@ -769,6 +795,7 @@ dependencies = [
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -16,4 +16,5 @@ neon-build = "0.2.0"
 [dependencies]
 neon = "0.2.0"
 neon-serde = "0.1.1"
+failure = "0.1.5"
 carmen-core = { path = "../" }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Aarthy Chandrasekhar <kcaarthy@gmail.com>"]
 license = "MIT"
 build = "build.rs"
 exclude = ["artifacts.json", "index.node"]
+edition = "2018"
 
 [lib]
 name = "node_carmen_core"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -56,21 +56,21 @@ declare_types! {
             let grid_key = cx.argument::<JsObject>(0)?;
             let grid_entry = cx.argument::<JsValue>(1)?;
             let values: Vec<GridEntry> = neon_serde::from_value(&mut cx, grid_entry)?;
-            let js_phrase_id = {
-                grid_key.get(&mut cx, "phrase_id")?
-            };
-            let phrase_id: u32 = {
-                js_phrase_id.downcast::<JsNumber>().or_throw(&mut cx)?.value() as u32
-            };
-            let js_lang_set = {
-                grid_key.get(&mut cx, "lang_set")?
-            };
+            let phrase_id: u32 = grid_key
+                .get(&mut cx, "phrase_id")?
+                .downcast::<JsNumber>()
+                .or_throw(&mut cx)?
+                .value() as u32;
 
-            let js_array_lang = {
-                js_lang_set.downcast::<JsArray>().or_throw(&mut cx)?
-            };
+            let js_lang_set = grid_key
+                .get(&mut cx, "lang_set")?
+                .downcast::<JsArray>()
+                .or_throw(&mut cx)?;
 
-            let lang_set: u128 = langarray_to_langset(&mut cx, js_array_lang)?;
+            let lang_set: u128 = langarray_to_langset(
+                &mut cx,
+                js_lang_set
+            )?;
 
             let key = GridKey { phrase_id, lang_set };
             let mut this = cx.this();

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate neon;
-extern crate carmen_core;
-extern crate neon_serde;
-extern crate failure;
 use carmen_core::gridstore::coalesce;
 use carmen_core::gridstore::PhrasematchSubquery;
 use carmen_core::gridstore::{
@@ -10,6 +5,7 @@ use carmen_core::gridstore::{
 };
 
 use neon::prelude::*;
+use neon::{class_definition, declare_types, impl_managed, register_module};
 use neon_serde::errors::Result as LibResult;
 use std::sync::Arc;
 use failure::Error;

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate neon;
 extern crate carmen_core;
 extern crate neon_serde;
+extern crate failure;
 use carmen_core::gridstore::coalesce;
 use carmen_core::gridstore::PhrasematchSubquery;
 use carmen_core::gridstore::{
@@ -10,8 +11,8 @@ use carmen_core::gridstore::{
 
 use neon::prelude::*;
 use neon_serde::errors::Result as LibResult;
-use std::error::Error;
 use std::sync::Arc;
+use failure::Error;
 
 type ArcGridStore = Arc<GridStore>;
 
@@ -51,7 +52,7 @@ declare_types! {
             let filename = cx.argument::<JsString>(0)?.value();
             match GridStoreBuilder::new(filename) {
                 Ok(s) => Ok(Some(s)),
-                Err(e) => cx.throw_type_error(e.description())
+                Err(e) => cx.throw_type_error(e.to_string())
             }
         }
 
@@ -81,7 +82,7 @@ declare_types! {
             // lock falls out of scope at the end of this block
             // in order to be able to borrow `cx` for the error block we assign it to a variable
 
-            let insert: Result<Result<(), Box<dyn Error>>, &str> = {
+            let insert: Result<Result<(), Error>, &str> = {
                 let lock = cx.lock();
                 let mut gridstore = this.borrow_mut(&lock);
                 match gridstore.as_mut() {
@@ -103,7 +104,7 @@ declare_types! {
         method finish(mut cx) {
             let mut this = cx.this();
 
-            let finish: Result<Result<(), Box<dyn Error>>, &str> = {
+            let finish: Result<Result<(), Error>, &str> = {
                 let lock = cx.lock();
                 let mut gridstore = this.borrow_mut(&lock);
                 match gridstore.take() {
@@ -128,7 +129,7 @@ declare_types! {
             let filename = cx.argument::<JsString>(0)?.value();
             match GridStore::new(filename) {
                 Ok(s) => Ok(Arc::new(s)),
-                Err(e) => cx.throw_type_error(e.description())
+                Err(e) => cx.throw_type_error(e.to_string())
             }
         }
     }

--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
-use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
 use morton::interleave_morton;
 use rocksdb::DB;
+use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;
@@ -36,12 +36,12 @@ fn extend_entries(builder_entry: &mut BuilderEntry, values: &[GridEntry]) -> () 
 
 impl GridStoreBuilder {
     /// Makes a new GridStoreBuilder with a particular filename.
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn Error>> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         Ok(GridStoreBuilder { path: path.as_ref().to_owned(), data: BTreeMap::new() })
     }
 
     /// Inserts a new GridStore entry with the given values.
-    pub fn insert(&mut self, key: &GridKey, values: &[GridEntry]) -> Result<(), Box<dyn Error>> {
+    pub fn insert(&mut self, key: &GridKey, values: &[GridEntry]) -> Result<(), Error> {
         let mut to_insert = BuilderEntry::new();
         extend_entries(&mut to_insert, values);
         self.data.insert(key.to_owned(), to_insert);
@@ -49,14 +49,14 @@ impl GridStoreBuilder {
     }
 
     ///  Appends a values to and existing GridStore entry.
-    pub fn append(&mut self, key: &GridKey, values: &[GridEntry]) -> Result<(), Box<dyn Error>> {
+    pub fn append(&mut self, key: &GridKey, values: &[GridEntry]) -> Result<(), Error> {
         let mut to_append = self.data.entry(key.to_owned()).or_insert_with(|| BuilderEntry::new());
         extend_entries(&mut to_append, values);
         Ok(())
     }
 
-    /// [wip] Writes data to disk.
-    pub fn finish(mut self) -> Result<(), Box<Error>> {
+    /// Writes data to disk.
+    pub fn finish(mut self) -> Result<(), Error> {
         let db = DB::open_default(&self.path)?;
         let mut db_key: Vec<u8> = Vec::with_capacity(MAX_KEY_LENGTH);
         for (grid_key, value) in self.data.iter_mut() {

--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use failure::Error;
 use itertools::Itertools;
 use morton::interleave_morton;
 use rocksdb::DB;
-use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -2,9 +2,9 @@ use std::borrow::Borrow;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
+use failure::Error;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::store::GridStore;

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -1,10 +1,10 @@
 use std::borrow::Borrow;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
+use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::store::GridStore;
@@ -14,7 +14,7 @@ use crate::gridstore::store::GridStore;
 pub fn coalesce<T: Borrow<GridStore> + Clone>(
     stack: Vec<PhrasematchSubquery<T>>,
     match_opts: &MatchOpts,
-) -> Result<Vec<CoalesceContext>, Box<Error>> {
+) -> Result<Vec<CoalesceContext>, Error> {
     let contexts = if stack.len() <= 1 {
         coalesce_single(&stack[0], match_opts)?
     } else {
@@ -87,7 +87,7 @@ fn grid_to_coalesce_entry<T: Borrow<GridStore> + Clone>(
 fn coalesce_single<T: Borrow<GridStore> + Clone>(
     subquery: &PhrasematchSubquery<T>,
     match_opts: &MatchOpts,
-) -> Result<Vec<CoalesceContext>, Box<Error>> {
+) -> Result<Vec<CoalesceContext>, Error> {
     let grids = subquery.store.borrow().get_matching(&subquery.match_key, match_opts)?;
     let mut contexts: Vec<CoalesceContext> = Vec::new();
     let mut max_relev: f32 = 0.;
@@ -163,7 +163,7 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
 fn coalesce_multi<T: Borrow<GridStore> + Clone>(
     mut stack: Vec<PhrasematchSubquery<T>>,
     match_opts: &MatchOpts,
-) -> Result<Vec<CoalesceContext>, Box<Error>> {
+) -> Result<Vec<CoalesceContext>, Error> {
     stack.sort_by_key(|subquery| (subquery.zoom, subquery.idx));
 
     let mut coalesced: HashMap<(u16, u16, u16), Vec<CoalesceContext>> = HashMap::new();

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use serde::{Deserialize, Serialize};
 use failure::Error;
+use serde::{Deserialize, Serialize};
 
 use crate::gridstore::store::GridStore;
 

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
-use std::error::Error;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::{Deserialize, Serialize};
+use failure::Error;
 
 use crate::gridstore::store::GridStore;
 
@@ -13,7 +13,7 @@ pub struct GridKey {
 }
 
 impl GridKey {
-    pub fn write_to(&self, type_marker: u8, db_key: &mut Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_to(&self, type_marker: u8, db_key: &mut Vec<u8>) -> Result<(), Error> {
         db_key.push(type_marker);
         // next goes the ID
         db_key.write_u32::<BigEndian>(self.phrase_id)?;
@@ -46,7 +46,7 @@ pub struct MatchKey {
 }
 
 impl MatchKey {
-    pub fn write_start_to(&self, type_marker: u8, db_key: &mut Vec<u8>) -> Result<(), Box<Error>> {
+    pub fn write_start_to(&self, type_marker: u8, db_key: &mut Vec<u8>) -> Result<(), Error> {
         db_key.push(type_marker);
         // next goes the ID
         let start = match self.match_phrase {
@@ -57,7 +57,7 @@ impl MatchKey {
         Ok(())
     }
 
-    pub fn matches_key(&self, db_key: &[u8]) -> Result<bool, Box<Error>> {
+    pub fn matches_key(&self, db_key: &[u8]) -> Result<bool, Error> {
         let key_phrase = (&db_key[1..]).read_u32::<BigEndian>()?;
         Ok(match self.match_phrase {
             MatchPhrase::Exact(phrase_id) => phrase_id == key_phrase,
@@ -65,7 +65,7 @@ impl MatchKey {
         })
     }
 
-    pub fn matches_language(&self, db_key: &[u8]) -> Result<bool, Box<Error>> {
+    pub fn matches_language(&self, db_key: &[u8]) -> Result<bool, Error> {
         let key_lang_partial = &db_key[5..];
         if key_lang_partial.len() == 0 {
             // 0-length language array is the shorthand for "matches everything"

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::error::Error;
 use std::path::Path;
 
 use byteorder::{LittleEndian, ReadBytesExt};
@@ -9,6 +8,7 @@ use itertools::Itertools;
 use morton::deinterleave_morton;
 use ordered_float::OrderedFloat;
 use rocksdb::{Direction, IteratorMode, Options, DB};
+use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;
@@ -131,7 +131,7 @@ fn eager_test() {
 }
 
 impl GridStore {
-    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn Error>> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let path = path.as_ref().to_owned();
         let mut opts = Options::default();
         opts.set_read_only(true);
@@ -142,7 +142,7 @@ impl GridStore {
     pub fn get(
         &self,
         key: &GridKey,
-    ) -> Result<Option<impl Iterator<Item = GridEntry>>, Box<Error>> {
+    ) -> Result<Option<impl Iterator<Item = GridEntry>>, Error> {
         let mut db_key: Vec<u8> = Vec::new();
         key.write_to(0, &mut db_key)?;
 
@@ -198,7 +198,7 @@ impl GridStore {
         &self,
         match_key: &MatchKey,
         match_opts: &MatchOpts,
-    ) -> Result<impl Iterator<Item = MatchEntry>, Box<Error>> {
+    ) -> Result<impl Iterator<Item = MatchEntry>, Error> {
         let mut db_key: Vec<u8> = Vec::new();
         match_key.write_start_to(0, &mut db_key)?;
 

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -3,12 +3,12 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use byteorder::{LittleEndian, ReadBytesExt};
+use failure::Error;
 use flatbuffers;
 use itertools::Itertools;
 use morton::deinterleave_morton;
 use ordered_float::OrderedFloat;
 use rocksdb::{Direction, IteratorMode, Options, DB};
-use failure::Error;
 
 use crate::gridstore::common::*;
 use crate::gridstore::gridstore_generated::*;
@@ -139,10 +139,7 @@ impl GridStore {
         Ok(GridStore { db })
     }
 
-    pub fn get(
-        &self,
-        key: &GridKey,
-    ) -> Result<Option<impl Iterator<Item = GridEntry>>, Error> {
+    pub fn get(&self, key: &GridKey) -> Result<Option<impl Iterator<Item = GridEntry>>, Error> {
         let mut db_key: Vec<u8> = Vec::new();
         key.write_to(0, &mut db_key)?;
 


### PR DESCRIPTION
This PR makes two tidying-up changes -- it's a tangent on the way to writing renumbering support in preparation for Carmen integration.

## failure
The first is to change how we're doing error handling to use the [failure](https://github.com/rust-lang-nursery/failure) crate. The `Result` type requires that you specify what types you're going to make your errors, and if you want to be able to use the `?` operator on results you get from calling other people's functions, you need to be able to coerce from whatever kind of errors you get back into the kind of error you return. The "grown up" way is for you to create your own error type, and then write converters from any kinds of errors you get into your error type. The laziest way is what we were doing before, which is `Box<dyn Error>` -- any kind of error, plus some vtable nonsense for good measure. `failure` is a library that's supposed to split the difference, making it practical to write your own error type if you need and mix that in with other people's errors without much boilerplate. (It's the successor to `error-chain`, which also serves about this purpose and is used, among other places, in neon-serde). I figured I would see how much work it was to switch, and it turns out... not much. Which is good, because I need to make my own error type for the renumbering thing I'm doing next.

## Rust 2018
While switching things over, I noticed in the `native` code for neon that had to add `extern crate` statements, which I didn't need to do in the main code. Turns out the main crate is using the [2018 edition](https://doc.rust-lang.org/edition-guide/rust-2018/index.html) of Rust, which doesn't require these anymore, but the Neon code was using 2015, so I switched it over for consistency.

@aarthykc turns out that also enabled [non-lexical lifetimes](https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/non-lexical-lifetimes.html), which means a lot of that boilerplate with it complaining about too many borrows of `&mut cx` fixed itself, and I was able to get rid of a bunch of those extra blocks and variables we had to add in to get `insert` to build before. So that's a bit tidier, too.