### PR TITLE
Renumbering

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "nyc": "^14.0.0"
   },
   "scripts": {
-    "install": "neon build",
+    "install": "neon build --release",
     "test": "node -e \"require('.')\"",
     "coverage": "nyc node -e \"require('.')\" && nyc report --reporter=text-lcov > coverage.lcov && codecov"
   }

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -51,6 +51,35 @@ mod tests {
     }
 
     #[test]
+    fn renumber_test() {
+        let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
+        let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
+
+        // phrase IDs are descending, grid IDs are ascending
+        let items = vec![
+            (GridKey { phrase_id: 2, lang_set: 1 }, GridEntry { id: 0, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
+            (GridKey { phrase_id: 1, lang_set: 1 }, GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
+            (GridKey { phrase_id: 0, lang_set: 1 }, GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
+        ];
+
+        for (key, val) in items {
+            builder.insert(&key, &vec![val]).expect("Unable to insert record");
+        }
+        builder.renumber(&vec![2, 1, 0]).unwrap();
+        // after renumbering, the IDs should match
+        builder.finish().unwrap();
+
+        let reader = GridStore::new(directory.path()).unwrap();
+
+        for id in 0..=2 {
+            let entries: Vec<_> = reader.get(
+                &GridKey { phrase_id: id, lang_set: 1 }
+            ).unwrap().unwrap().collect();
+            assert_eq!(id, entries[0].id);
+        }
+    }
+
+    #[test]
     fn phrase_hash_test() {
         let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
         let mut builder = GridStoreBuilder::new(directory.path()).unwrap();

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -57,9 +57,18 @@ mod tests {
 
         // phrase IDs are descending, grid IDs are ascending
         let items = vec![
-            (GridKey { phrase_id: 2, lang_set: 1 }, GridEntry { id: 0, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
-            (GridKey { phrase_id: 1, lang_set: 1 }, GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
-            (GridKey { phrase_id: 0, lang_set: 1 }, GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 }),
+            (
+                GridKey { phrase_id: 2, lang_set: 1 },
+                GridEntry { id: 0, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
+            ),
+            (
+                GridKey { phrase_id: 1, lang_set: 1 },
+                GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
+            ),
+            (
+                GridKey { phrase_id: 0, lang_set: 1 },
+                GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
+            ),
         ];
 
         for (key, val) in items {
@@ -72,9 +81,8 @@ mod tests {
         let reader = GridStore::new(directory.path()).unwrap();
 
         for id in 0..=2 {
-            let entries: Vec<_> = reader.get(
-                &GridKey { phrase_id: id, lang_set: 1 }
-            ).unwrap().unwrap().collect();
+            let entries: Vec<_> =
+                reader.get(&GridKey { phrase_id: id, lang_set: 1 }).unwrap().unwrap().collect();
             assert_eq!(id, entries[0].id);
         }
     }


### PR DESCRIPTION
Unlike carmen-cache, entries in the carmen-core grid store are keyed by phrase ID instead of by string. IDs will be assigned by fuzzy-phrase as of https://github.com/mapbox/fuzzy-phrase/pull/71 . However, the actual ID for each phrase isn't known until all phrases have been indexed, so in an indexing context in carmen, where we're processing features one at a time and adding their phrase and grid data to both the fuzzy-phrase index and the grid store, we need a temporary identifier. The fuzzy-phrase PR provides for returning a temporary ID after each fuzzy-phrase insert, and then for providing a mapping from temporary IDs to final IDs after the structure is built. This PR introduces a mechanism for consuming that mapping (expressed just as a vector of IDs, where the index is the temporary ID and the value at that index is the final ID), and under the assumption that all inserts so far have been with temporary IDs; it rewrites its internal temporary storage to use the new IDs instead of the old ones.

Also included is a Neon wrapper, which assumes the vector of u32's will be represented in Javascript as a JsArrayBuffer -- this matches the output of the corresponding function on the fuzzy-phrase side.

Tests are in place for Rust. I'll write some JS tests as well, but will wait until @aarthykc 's test work lands to avoid merge conflict unpleasantness.