### PR TITLE
Things for Carmen

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
 var addon = require('./native');
 
+// wire up iterator creation from the JS side
+addon.GridStore.prototype.keys = function() {
+    const out = {};
+    out[Symbol.iterator] = () => new addon.GridStoreKeyIterator(this);
+    return out;
+}
+
 module.exports = addon;

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -429,6 +430,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,6 +593,11 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -773,6 +787,7 @@ dependencies = [
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -793,6 +808,7 @@ dependencies = [
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
 "checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -18,4 +18,5 @@ neon-build = "0.2.0"
 neon = "0.2.0"
 neon-serde = "0.1.1"
 failure = "0.1.5"
+owning_ref = "0.4"
 carmen-core = { path = "../" }

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -176,7 +176,7 @@ mod tests {
         ];
 
         let mut i = 0;
-        for key in keys {
+        for key in keys.iter() {
             for _j in 0..2 {
                 #[cfg_attr(rustfmt, rustfmt::skip)]
                 let entries = vec![
@@ -187,7 +187,7 @@ mod tests {
                 ];
                 i += 4;
 
-                builder.insert(&key, &entries).expect("Unable to insert record");
+                builder.insert(key, &entries).expect("Unable to insert record");
             }
         }
 
@@ -425,6 +425,12 @@ mod tests {
                 MatchEntry { grid_entry: GridEntry { relev: 1.0, score: 1, x: 40, y: 1, id: 20, source_phrase_hash: 0 }, matches_language: false }
             ]
         );
+
+        let listed_keys: Result<Vec<_>, _> = reader.keys().collect();
+        let mut orig_keys = keys.clone();
+        orig_keys.sort();
+        orig_keys.dedup();
+        assert_eq!(listed_keys.unwrap(), orig_keys);
     }
 
     #[test]

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use byteorder::{LittleEndian, BigEndian, ReadBytesExt};
+use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use failure::Error;
 use flatbuffers;
 use itertools::Itertools;
@@ -342,7 +342,7 @@ impl GridStore {
         Ok(out)
     }
 
-    pub fn keys<'i>(&'i self) -> impl Iterator<Item=Result<GridKey, Error>> + 'i {
+    pub fn keys<'i>(&'i self) -> impl Iterator<Item = Result<GridKey, Error>> + 'i {
         let db_iter = self.db.iterator(IteratorMode::Start);
         db_iter.take_while(|(key, _)| key[0] == 0).map(|(key, _)| {
             let phrase_id = (&key[1..]).read_u32::<BigEndian>()?;


### PR DESCRIPTION
This branch is a running set of additions necessary to get tests passing in Carmen. It's a superset of #24, so that should go in first.

Major so far in addition to that:
- [x] wrap the `append` method for the builder (and along the way, factor out part of `insert` so it can be used with both).
- [x] make the wrappers for `coalesce` expect lang_set fields as arrays just like insert does, and also handle undefined or null (interpret them as all-languages) like carmen-cache does
- [x] add `keys()` method emulating the `list()` method in carmen-cache, except that it produces an iterator rather than an array. On the Rust side this is a regular Rust iterator, and on the JS side it's a JS iterator, with some conversion between the two. A little JS-side work was necessary as well for this one, as it's not possible to construct new instances of Neon classes from Rust.
- [x] expose the `get` method on the gridstore

The new Rust-side functionality (`keys()`) is tested. New JS-side functionality is not tested yet, but tests are being worked on in another PR so we'll plan to merge this as-is to unblock that work.