### PR TITLE
More js wrapper tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,20 +13,21 @@
   "author": "Aarthy Chandrasekhar <kcaarthy@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "node-pre-gyp": "~0.13.0",
-    "neon-cli": "^0.2.0"
+    "neon-cli": "^0.2.0",
+    "node-pre-gyp": "~0.13.0"
   },
   "devDependencies": {
+    "@mapbox/cfn-config": "^2.15.0",
+    "@mapbox/cloudfriend": "^1.9.1",
     "codecov": "^3.3.0",
     "neon-cli": "^0.2.0",
     "nyc": "^14.0.0",
-    "@mapbox/cfn-config": "^2.15.0",
-    "@mapbox/cloudfriend": "^1.9.1"
+    "tape": "^4.10.2"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build=false || neon build --release",
     "build": "neon build --release",
-    "test": "node -e \"require('.')\"",
+    "test": "tape ./test/bindings/*",
     "coverage": "nyc node -e \"require('.')\" && nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "binary": {

--- a/test/bindings/test.js
+++ b/test/bindings/test.js
@@ -5,70 +5,70 @@ const tape = require('tape');
 const tmp = require('tmp');
 const rimraf = require('rimraf').sync;
 
-tape('JsGridbuilderBuilder init', (t) => {
+tape('JsGridStoreBuilder init', (t) => {
     const tmpDir = tmp.dirSync();
-    t.throws(() => new addon.GridbuilderBuilder(), 'not enough arguments');
-    t.throws(() => new addon.GridbuilderBuilder({}), 'throws on wrong argument type');
-    t.throws(() => new addon.GridbuilderBuilder(7), 'throws on wrong argument type');
-    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    t.throws(() => new addon.GridStoreBuilder(), 'not enough arguments');
+    t.throws(() => new addon.GridStoreBuilder({}), 'throws on wrong argument type');
+    t.throws(() => new addon.GridStoreBuilder(7), 'throws on wrong argument type');
+    const builder = new addon.GridStoreBuilder(tmpDir.name);
     t.ok(builder);
     rimraf(tmpDir.name);
     t.end();
 });
 
-tape('GridbuilderBuilder insert()', (t) => {
+tape('GridStoreBuilder insert()', (t) => {
     const tmpDir = tmp.dirSync();
-    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    const builder = new addon.GridStoreBuilder(tmpDir.name);
     t.throws(() => builder.insert(), 'not enough arguments');
     t.throws(() => builder.insert({}), 'not enough arguments');
     builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.6, score: 3, source_phrase_hash: 0 }]);
     builder.finish();
 
-    const reader = new addon.Gridbuilder(tmpDir.name);
+    const reader = new addon.GridStore(tmpDir.name);
     t.deepEquals(reader.get({ phrase_id: 0, lang_set: [0] }), [ { relev: 1, score: 2, x: 0, y: 0, id: 0, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
     t.deepEquals(reader.get({ phrase_id: 1, lang_set: [0, 1, 2, 3] }), [ { relev: 0.6, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
     t.notOk(reader.get({ phrase_id: 3, lang_set: [3] }), 'cannot retrieve a grid that has not been inserted');
     t.end();
 });
 
-tape('GridbuilderBuilder append()', (t) => {
+tape('GridStoreBuilder append()', (t) => {
     const tmpDir = tmp.dirSync();
-    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    const builder = new addon.GridStoreBuilder(tmpDir.name);
     t.throws(() => builder.append(), 'not enough arguments');
     t.throws(() => builder.append({}), 'not enough arguments');
     builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     builder.append({ phrase_id: 1, lang_set: [0, 2] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
     builder.finish();
 
-    const reader = new addon.Gridbuilder(tmpDir.name);
+    const reader = new addon.GridStore(tmpDir.name);
     let list = Array.from(reader.keys());
-    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 2 ] } ], 'Gridbuilder contains the key inserted and the key appended');
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 2 ] } ], 'GridStore contains the key inserted and the key appended');
     t.end();
 });
 
-tape('GridbuilderBuilder finish()', (t) => {
+tape('GridStoreBuilder finish()', (t) => {
     const tmpDir = tmp.dirSync();
-    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    const builder = new addon.GridStoreBuilder(tmpDir.name);
     builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
-    t.throws(() => new addon.Gridbuilder(tmpDir.name), 'throws if you attempt to read without calling finish()');
+    t.throws(() => new addon.GridStore(tmpDir.name), 'throws if you attempt to read without calling finish()');
 
     builder.finish();
-    const reader = new addon.Gridbuilder(tmpDir.name);
+    const reader = new addon.GridStore(tmpDir.name);
     t.ok(reader, 'can read only after finish() is called');
     t.end();
 });
 
-tape('Gridbuilder reader', (t) => {
+tape('GridStore reader', (t) => {
     const tmpDir = tmp.dirSync();
-    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    const builder = new addon.GridStoreBuilder(tmpDir.name);
     builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
     builder.finish();
 
-    const reader = new addon.Gridbuilder(tmpDir.name);
+    const reader = new addon.GridStore(tmpDir.name);
     let list = Array.from(reader.keys());
-    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 1, 2, 3 ] } ], 'Gridbuilder is able to retrieve keys, reader works as expected');
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 1, 2, 3 ] } ], 'GridStore is able to retrieve keys, reader works as expected');
     t.end();
 });

--- a/test/bindings/test.js
+++ b/test/bindings/test.js
@@ -3,25 +3,52 @@
 const addon = require('../../');
 const tape = require('tape');
 const tmp = require('tmp');
+const rimraf = require('rimraf').sync;
 
 tape('JsGridStoreBuilder init', (t) => {
     const tmpDir = tmp.dirSync();
     t.throws(() => new addon.GridStoreBuilder(), 'not enough arguments');
+    t.throws(() => new addon.GridStoreBuilder({}), 'throws on wrong argument type');
+    t.throws(() => new addon.GridStoreBuilder(7), 'throws on wrong argument type');
     const store = new addon.GridStoreBuilder(tmpDir.name);
     t.ok(store);
+    rimraf(tmpDir.name);
     t.end();
 });
 
-tape('JsGridStoreBuilder insert', (t) => {
+tape('GridStoreBuilder insert()', (t) => {
     const tmpDir = tmp.dirSync();
     const store = new addon.GridStoreBuilder(tmpDir.name);
-    t.throws(() => grid.insert(), 'not enough arguments');
-    const id = {
-        phrase_id: 1,
-        lang_set: [0, 1, 2, 3]
-    };
-    const entries = [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }];
-    store.insert(id, entries);
-    t.ok(store);
+    t.throws(() => store.insert(), 'not enough arguments');
+    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.6, score: 3, source_phrase_hash: 0 }]);
+    store.finish();
+
+    const reader = new addon.GridStore(tmpDir.name);
+    t.deepEquals(reader.get({ phrase_id: 0, lang_set: [0] }), [ { relev: 1, score: 2, x: 0, y: 0, id: 0, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
+    t.deepEquals(reader.get({ phrase_id: 1, lang_set: [0, 1, 2, 3] }), [ { relev: 0.6000000238418579, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
+    t.end();
+});
+
+tape('GridStoreBuilder finish()', (t) => {
+    const tmpDir = tmp.dirSync();
+    const store = new addon.GridStoreBuilder(tmpDir.name);
+    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+
+    t.throws(() => new addon.GridStore(tmpDir.name), 'throws if you attempt to read without calling finish()');
+    t.end();
+});
+
+tape('GridStore', (t) => {
+    const tmpDir = tmp.dirSync();
+    const store = new addon.GridStoreBuilder(tmpDir.name);
+    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+    store.finish();
+
+    const reader = new addon.GridStore(tmpDir.name);
+    let list = Array.from(reader.keys());
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 1, 2, 3 ] } ], 'GridStore is able to retrieve keys, reader works as expected');
     t.end();
 });

--- a/test/bindings/test.js
+++ b/test/bindings/test.js
@@ -20,13 +20,30 @@ tape('GridStoreBuilder insert()', (t) => {
     const tmpDir = tmp.dirSync();
     const store = new addon.GridStoreBuilder(tmpDir.name);
     t.throws(() => store.insert(), 'not enough arguments');
+    t.throws(() => store.insert({}), 'not enough arguments');
     store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.6, score: 3, source_phrase_hash: 0 }]);
     store.finish();
 
     const reader = new addon.GridStore(tmpDir.name);
     t.deepEquals(reader.get({ phrase_id: 0, lang_set: [0] }), [ { relev: 1, score: 2, x: 0, y: 0, id: 0, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
-    t.deepEquals(reader.get({ phrase_id: 1, lang_set: [0, 1, 2, 3] }), [ { relev: 0.6000000238418579, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
+    t.deepEquals(reader.get({ phrase_id: 1, lang_set: [0, 1, 2, 3] }), [ { relev: 0.6, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
+    t.notOk(reader.get({ phrase_id: 3, lang_set: [3] }), 'cannot retrieve a grid that has not been inserted');
+    t.end();
+});
+
+tape('GridStoreBuilder append()', (t) => {
+    const tmpDir = tmp.dirSync();
+    const store = new addon.GridStoreBuilder(tmpDir.name);
+    t.throws(() => store.append(), 'not enough arguments');
+    t.throws(() => store.append({}), 'not enough arguments');
+    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    store.append({ phrase_id: 1, lang_set: [0, 2] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+    store.finish();
+
+    const reader = new addon.GridStore(tmpDir.name);
+    let list = Array.from(reader.keys());
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 2 ] } ], 'GridStore contains the key inserted and the key appended');
     t.end();
 });
 
@@ -35,12 +52,15 @@ tape('GridStoreBuilder finish()', (t) => {
     const store = new addon.GridStoreBuilder(tmpDir.name);
     store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
     store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
-
     t.throws(() => new addon.GridStore(tmpDir.name), 'throws if you attempt to read without calling finish()');
+
+    store.finish();
+    const reader = new addon.GridStore(tmpDir.name);
+    t.ok(reader, 'can read only after finish() is called');
     t.end();
 });
 
-tape('GridStore', (t) => {
+tape('GridStore reader', (t) => {
     const tmpDir = tmp.dirSync();
     const store = new addon.GridStoreBuilder(tmpDir.name);
     store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);

--- a/test/bindings/test.js
+++ b/test/bindings/test.js
@@ -5,70 +5,70 @@ const tape = require('tape');
 const tmp = require('tmp');
 const rimraf = require('rimraf').sync;
 
-tape('JsGridStoreBuilder init', (t) => {
+tape('JsGridbuilderBuilder init', (t) => {
     const tmpDir = tmp.dirSync();
-    t.throws(() => new addon.GridStoreBuilder(), 'not enough arguments');
-    t.throws(() => new addon.GridStoreBuilder({}), 'throws on wrong argument type');
-    t.throws(() => new addon.GridStoreBuilder(7), 'throws on wrong argument type');
-    const store = new addon.GridStoreBuilder(tmpDir.name);
-    t.ok(store);
+    t.throws(() => new addon.GridbuilderBuilder(), 'not enough arguments');
+    t.throws(() => new addon.GridbuilderBuilder({}), 'throws on wrong argument type');
+    t.throws(() => new addon.GridbuilderBuilder(7), 'throws on wrong argument type');
+    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    t.ok(builder);
     rimraf(tmpDir.name);
     t.end();
 });
 
-tape('GridStoreBuilder insert()', (t) => {
+tape('GridbuilderBuilder insert()', (t) => {
     const tmpDir = tmp.dirSync();
-    const store = new addon.GridStoreBuilder(tmpDir.name);
-    t.throws(() => store.insert(), 'not enough arguments');
-    t.throws(() => store.insert({}), 'not enough arguments');
-    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
-    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.6, score: 3, source_phrase_hash: 0 }]);
-    store.finish();
+    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    t.throws(() => builder.insert(), 'not enough arguments');
+    t.throws(() => builder.insert({}), 'not enough arguments');
+    builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.6, score: 3, source_phrase_hash: 0 }]);
+    builder.finish();
 
-    const reader = new addon.GridStore(tmpDir.name);
+    const reader = new addon.Gridbuilder(tmpDir.name);
     t.deepEquals(reader.get({ phrase_id: 0, lang_set: [0] }), [ { relev: 1, score: 2, x: 0, y: 0, id: 0, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
     t.deepEquals(reader.get({ phrase_id: 1, lang_set: [0, 1, 2, 3] }), [ { relev: 0.6, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 } ], 'able to find the correct gridEntry inserted by insert()');
     t.notOk(reader.get({ phrase_id: 3, lang_set: [3] }), 'cannot retrieve a grid that has not been inserted');
     t.end();
 });
 
-tape('GridStoreBuilder append()', (t) => {
+tape('GridbuilderBuilder append()', (t) => {
     const tmpDir = tmp.dirSync();
-    const store = new addon.GridStoreBuilder(tmpDir.name);
-    t.throws(() => store.append(), 'not enough arguments');
-    t.throws(() => store.append({}), 'not enough arguments');
-    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
-    store.append({ phrase_id: 1, lang_set: [0, 2] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
-    store.finish();
+    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    t.throws(() => builder.append(), 'not enough arguments');
+    t.throws(() => builder.append({}), 'not enough arguments');
+    builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    builder.append({ phrase_id: 1, lang_set: [0, 2] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+    builder.finish();
 
-    const reader = new addon.GridStore(tmpDir.name);
+    const reader = new addon.Gridbuilder(tmpDir.name);
     let list = Array.from(reader.keys());
-    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 2 ] } ], 'GridStore contains the key inserted and the key appended');
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 2 ] } ], 'Gridbuilder contains the key inserted and the key appended');
     t.end();
 });
 
-tape('GridStoreBuilder finish()', (t) => {
+tape('GridbuilderBuilder finish()', (t) => {
     const tmpDir = tmp.dirSync();
-    const store = new addon.GridStoreBuilder(tmpDir.name);
-    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
-    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
-    t.throws(() => new addon.GridStore(tmpDir.name), 'throws if you attempt to read without calling finish()');
+    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+    t.throws(() => new addon.Gridbuilder(tmpDir.name), 'throws if you attempt to read without calling finish()');
 
-    store.finish();
-    const reader = new addon.GridStore(tmpDir.name);
+    builder.finish();
+    const reader = new addon.Gridbuilder(tmpDir.name);
     t.ok(reader, 'can read only after finish() is called');
     t.end();
 });
 
-tape('GridStore reader', (t) => {
+tape('Gridbuilder reader', (t) => {
     const tmpDir = tmp.dirSync();
-    const store = new addon.GridStoreBuilder(tmpDir.name);
-    store.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
-    store.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
-    store.finish();
+    const builder = new addon.GridbuilderBuilder(tmpDir.name);
+    builder.insert({ phrase_id: 0, lang_set: [0] }, [{ id: 0, x: 0, y: 0, relev: 0.5, score: 2, source_phrase_hash: 0 }]);
+    builder.insert({ phrase_id: 1, lang_set: [0, 1, 2, 3] }, [{ id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 }]);
+    builder.finish();
 
-    const reader = new addon.GridStore(tmpDir.name);
+    const reader = new addon.Gridbuilder(tmpDir.name);
     let list = Array.from(reader.keys());
-    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 1, 2, 3 ] } ], 'GridStore is able to retrieve keys, reader works as expected');
+    t.deepEquals(list, [ { phrase_id: 0, lang_set: [ 0 ] }, { phrase_id: 1, lang_set: [ 0, 1, 2, 3 ] } ], 'Gridbuilder is able to retrieve keys, reader works as expected');
     t.end();
 });


### PR DESCRIPTION
As a follow up to #25 and #22 this PR adds more tests for the javascript wrappers for the GridStore and GridStoreBuilder. The functions we should add tests for are: 

1. insert()
2. finish()
3. append() 
4. reader

cc @apendleton, @Nmargolis 