### PR TITLE
Add test_utils crate for utils shared by tests and bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "rocksdb 0.12.2 (git+https://github.com/apendleton/rust-rocksdb.git?rev=f6a9d278262f090790578dbf435e591748c4622e)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test_utils 0.1.0",
 ]
 
 [[package]]
@@ -648,6 +649,14 @@ dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "test_utils"
+version = "0.1.0"
+dependencies = [
+ "carmen-core 0.1.0",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ failure = "0.1.5"
 
 [dev-dependencies]
 tempfile = "3.0"
+test_utils = { path = "test_utils" }
 
 # we're using a forked rocksdb for now because upstream rust-rocksdb doesn't yet
 # support read-only opens; can switch back to upstream once

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,0 +1,9 @@
+
+[package]
+name = "test_utils"
+version = "0.1.0"
+authors = ["Natalia Margolis <natalia.margolis@mapbox.com>"]
+
+[dependencies]
+tempfile = "3.0"
+carmen-core = { path = "../" }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate carmen_core;
 use carmen_core::gridstore::*;
 
 // Util functions

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -1,7 +1,5 @@
 use carmen_core::gridstore::*;
-mod common;
-
-use common::*;
+use test_utils::*;
 
 const ALL_LANGUAGES: u128 = u128::max_value();
 


### PR DESCRIPTION
### Context
Benchmarks will need to use some of the same utils as the tests, so it makes sense to have these utils in a separate crate that can be shared by both

### Summary of changes
- [x] Moves test utilities into a test_utils sub-crate
