### PR TITLE
[WIP] Prefix Store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-order-change-1",
+  "version": "0.1.0-prefix-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -70,7 +70,7 @@ fn get_fb_value(value: &mut BuilderEntry) -> Result<Vec<u8>, Error> {
     let record =
         PhraseRecord::create(&mut fb_builder, &PhraseRecordArgs { relev_scores: Some(fb_rses) });
     fb_builder.finish(record, None);
-    Ok(fb_builder.finished_data().to_owned())
+    Ok(fb_builder.finished_data().to_vec())
 }
 
 impl GridStoreBuilder {

--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -151,9 +151,10 @@ impl GridStoreBuilder {
                 let db_data = get_fb_value(value)?;
                 db.put(&db_key, &db_data)?;
             }
+            db_key.clear();
             group_key.write_to(1, &mut db_key)?;
             let grouped_db_data = get_fb_value(&mut grouped_entry)?;
-            //db.put(&db_key, &grouped_db_data);
+            db.put(&db_key, &grouped_db_data);
         }
 
         drop(db);

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -57,9 +57,9 @@ impl MatchKey {
         Ok(())
     }
 
-    pub fn matches_key(&self, db_key: &[u8]) -> Result<bool, Error> {
+    pub fn matches_key(&self, type_marker: u8, db_key: &[u8]) -> Result<bool, Error> {
         let key_phrase = (&db_key[1..]).read_u32::<BigEndian>()?;
-        if db_key[0] != 0 {
+        if db_key[0] != type_marker {
             return Ok(false);
         }
         Ok(match self.match_phrase {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -59,6 +59,9 @@ impl MatchKey {
 
     pub fn matches_key(&self, db_key: &[u8]) -> Result<bool, Error> {
         let key_phrase = (&db_key[1..]).read_u32::<BigEndian>()?;
+        if db_key[0] != 0 {
+            return Ok(false);
+        }
         Ok(match self.match_phrase {
             MatchPhrase::Exact(phrase_id) => phrase_id == key_phrase,
             MatchPhrase::Range { start, end } => start <= key_phrase && key_phrase < end,

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -428,4 +428,120 @@ mod tests {
         orig_keys.dedup();
         assert_eq!(listed_keys.unwrap(), orig_keys);
     }
+
+    #[test]
+    fn prefix_test() {
+        let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
+        let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
+
+        for i in 0..=2400 {
+            let key = GridKey { phrase_id: i, lang_set: 1 };
+            let entries = vec![GridEntry {
+                id: i,
+                x: i as u16,
+                y: 1,
+                relev: 1.,
+                score: 1,
+                source_phrase_hash: 0,
+            }];
+            builder.insert(&key, &entries).expect("Unable to insert record");
+        }
+
+        builder.finish().unwrap();
+
+        let reader = GridStore::new(directory.path()).unwrap();
+        let search_key =
+            MatchKey { match_phrase: MatchPhrase::Range { start: 800, end: 2049 }, lang_set: 1 };
+        let mut records: Vec<_> =
+            reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+        records.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let mut expected = Vec::new();
+        for i in 800..=2048 {
+            expected.push(MatchEntry {
+                grid_entry: GridEntry {
+                    relev: 1.0,
+                    score: 1,
+                    x: i as u16,
+                    y: 1,
+                    id: i,
+                    source_phrase_hash: 0,
+                },
+                matches_language: true,
+                distance: 0.0,
+                scoredist: 1.0,
+            })
+        }
+        assert_eq!(records, expected);
+
+        let search_key =
+            MatchKey { match_phrase: MatchPhrase::Range { start: 1024, end: 2049 }, lang_set: 1 };
+        let mut records: Vec<_> =
+            reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+        records.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let mut expected = Vec::new();
+        for i in 1024..=2048 {
+            expected.push(MatchEntry {
+                grid_entry: GridEntry {
+                    relev: 1.0,
+                    score: 1,
+                    x: i as u16,
+                    y: 1,
+                    id: i,
+                    source_phrase_hash: 0,
+                },
+                matches_language: true,
+                distance: 0.0,
+                scoredist: 1.0,
+            })
+        }
+        assert_eq!(records, expected);
+
+        let search_key =
+            MatchKey { match_phrase: MatchPhrase::Range { start: 1000, end: 2024 }, lang_set: 1 };
+        let mut records: Vec<_> =
+            reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+
+        records.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let mut expected = Vec::new();
+        for i in 1000..=2023 {
+            expected.push(MatchEntry {
+                grid_entry: GridEntry {
+                    relev: 1.0,
+                    score: 1,
+                    x: i as u16,
+                    y: 1,
+                    id: i,
+                    source_phrase_hash: 0,
+                },
+                matches_language: true,
+                distance: 0.0,
+                scoredist: 1.0,
+            })
+        }
+        assert_eq!(records, expected);
+
+        let search_key =
+            MatchKey { match_phrase: MatchPhrase::Range { start: 1024, end: 2048 }, lang_set: 1 };
+        let mut records: Vec<_> =
+            reader.get_matching(&search_key, &MatchOpts::default()).unwrap().collect();
+        records.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let mut expected = Vec::new();
+        for i in 1024..=2047 {
+            expected.push(MatchEntry {
+                grid_entry: GridEntry {
+                    relev: 1.0,
+                    score: 1,
+                    x: i as u16,
+                    y: 1,
+                    id: i,
+                    source_phrase_hash: 0,
+                },
+                matches_language: true,
+                distance: 0.0,
+                scoredist: 1.0,
+            })
+        }
+        assert_eq!(records, expected);
+    }
 }


### PR DESCRIPTION
## Context
### Builder
Per #38, this PR creates a prefix store and modifies `get_matching()` to read from the prefix store. When we call `finish()` the idea is that we create pre combined groups of 1024 entries. For example, grid entries with `phrase_ids` from 0 - 1023 will be combined under one `phrase_id`.

### Reader
In phrasematch when we get a range of grids to look up, we check to see if the range starts before, at or after the prefix bucket (since they're buckets of 1024, prefix ranges will be 1024 - 2047 etc) and similarly for the end. If the range starts before the prefix we'll iterate through the regular entries, then the prefix entries all the way to the end of the range provided. For example, if the user searches for the range 1000 - 2049 we'll scan through the following: 
- 1000 - 1023 - Regular entries 
- 1024 - 2047 - Prefix entries 
- 2048 - 2049 - Regular entries

## Next actions:
- [x] Publish a dev version and see if tests still pass for carmen - [Yes the do!](https://github.com/mapbox/carmen/commits/prefix-store)
- [x] Get the PR reviewed 
- [x] Merge

cc @apendleton @Nmargolis 