### PR TITLE
[publish binary] Binary built with rustc 1.36 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-prefix-1",
+  "version": "0.1.0-dev",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Context
The binary built with the most recent version of rustc interacts strangely with carmen-core and the binary for [node-fuzzy-phrase](https://github.com/mapbox/node-fuzzy-phrase/) built with an older version of rustc (1.35) - causing segmentation faults. The workaround is to have prebuilt binaries for node-fuzzy-phrase and carmen-core built with the newest version of rustc (1.36). This PR builds carmen-core with the newest version of rustc (1.36).

cc @apendleton, @Nmargolis 