### PR TITLE
Fix proximity radius comparison and use strict dedupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-prox-radius-dedupe-1",
+  "version": "0.1.0-prox-radius-dedupe-3",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-prefix-1",
+  "version": "0.1.0-prox-radius-dedupe-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-prox-radius-dedupe-3",
+  "version": "0.1.0-prox-radius-dedupe-4",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::cmp::Reverse;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use failure::Error;
@@ -110,16 +111,16 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
         let current_scoredist = coalesce_entry.scoredist;
 
         // If it's the same feature as one that's been added before, but a higher scoredist, update the entry
-        match coalesced.get(&current_id) {
-            Some(already_coalesced) => {
-                if current_scoredist > already_coalesced.scoredist
-                    && current_relev >= already_coalesced.grid_entry.relev
+        match coalesced.entry(current_id) {
+            Entry::Occupied(mut already_coalesced) => {
+                if current_scoredist > already_coalesced.get().scoredist
+                    && current_relev >= already_coalesced.get().grid_entry.relev
                 {
-                    coalesced.insert(current_id, coalesce_entry);
+                    already_coalesced.insert(coalesce_entry);
                 }
             }
-            None => {
-                coalesced.insert(current_id, coalesce_entry);
+            Entry::Vacant(entry) => {
+                entry.insert(coalesce_entry);
             }
         }
 

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -68,7 +68,6 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
     match_opts: &MatchOpts,
 ) -> Result<Vec<CoalesceContext>, Error> {
     let grids = subquery.store.borrow().get_matching(&subquery.match_key, match_opts)?;
-    let mut contexts: Vec<CoalesceContext> = Vec::new();
     let mut max_relev: f64 = 0.;
     // TODO: rename all of the last things to previous things
     let mut last_id: u32 = 0;
@@ -77,6 +76,8 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
     let mut min_scoredist = std::f64::MAX;
     let mut feature_count: usize = 0;
     let bigger_max = 2 * MAX_CONTEXTS;
+
+    let mut coalesced: HashMap<(u32), CoalesceEntry> = HashMap::new();
 
     for grid in grids {
         let coalesce_entry = grid_to_coalesce_entry(&grid, subquery, match_opts);
@@ -102,26 +103,48 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
         if coalesce_entry.grid_entry.relev > max_relev {
             max_relev = coalesce_entry.grid_entry.relev;
         }
-        // For coalesce single, there is only one coalesce entry per context
-        contexts.push(CoalesceContext {
-            mask: coalesce_entry.mask,
-            relev: coalesce_entry.grid_entry.relev,
-            entries: vec![coalesce_entry.clone()],
-        });
 
-        if last_id != coalesce_entry.grid_entry.id {
+        // Save current values before mocing into coalesced
+        let current_id = coalesce_entry.grid_entry.id;
+        let current_relev = coalesce_entry.grid_entry.relev;
+        let current_scoredist = coalesce_entry.scoredist;
+
+        // If it's the same feature as one that's been added before, but a higher scoredist, update the entry
+        match coalesced.get(&current_id) {
+            Some(already_coalesced) => {
+                if current_scoredist > already_coalesced.scoredist
+                    && current_relev >= already_coalesced.grid_entry.relev
+                {
+                    coalesced.insert(current_id, coalesce_entry);
+                }
+            }
+            None => {
+                coalesced.insert(current_id, coalesce_entry);
+            }
+        }
+
+        if last_id != current_id {
             feature_count += 1;
         }
         if match_opts.proximity.is_none() && feature_count > bigger_max {
             break;
         }
-        if coalesce_entry.scoredist < min_scoredist {
-            min_scoredist = coalesce_entry.scoredist;
+        if current_scoredist < min_scoredist {
+            min_scoredist = current_scoredist;
         }
-        last_id = coalesce_entry.grid_entry.id;
-        last_relev = coalesce_entry.grid_entry.relev;
-        last_scoredist = coalesce_entry.scoredist;
+        last_id = current_id;
+        last_relev = current_relev;
+        last_scoredist = current_scoredist;
     }
+
+    let mut contexts: Vec<CoalesceContext> = coalesced
+        .iter()
+        .map(|(_, entry)| CoalesceContext {
+            entries: vec![entry.clone()],
+            mask: entry.mask,
+            relev: entry.grid_entry.relev,
+        })
+        .collect();
 
     contexts.sort_by_key(|context| {
         (
@@ -133,7 +156,6 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
         )
     });
 
-    contexts.dedup_by_key(|context| context.entries[0].grid_entry.id);
     contexts.truncate(MAX_CONTEXTS);
     Ok(contexts)
 }

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -521,7 +521,7 @@ fn tiles_per_mile_by_zoom_test() {
 
 /// Convert proximity radius from miles into scaled number of tiles
 #[inline]
-fn proximity_radius(zoom: u16, radius: f64) -> f64 {
+pub fn proximity_radius(zoom: u16, radius: f64) -> f64 {
     debug_assert!(zoom <= 16);
     // In carmen-cache, there's an array of pre-calculated values for zooms 6-14, otherwise it does the exact same calculation as zoomTileRadius (now tiles_per_mile)
     // Does this even need to be a function?

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -330,7 +330,9 @@ impl GridStore {
                                     spatial::tile_dist(prox_pt.point[0], prox_pt.point[1], x, y);
                                 (
                                     distance,
-                                    distance <= prox_pt.radius,
+                                    // The proximity radius calculation is also done in scoredist
+                                    // There could be an opportunity to optimize by doing it once
+                                    distance <= spatial::proximity_radius(*zoom, prox_pt.radius),
                                     spatial::scoredist(*zoom, distance, score, prox_pt.radius),
                                 )
                             }


### PR DESCRIPTION
## Context

### Proximity radius check for language penalty
A language penalty is applied to the relevance score of features that don't match the language of the subquery. When proximity is specified, the language penalty is not applied if the grid is within the proximity radius. This provides better results for the  "tourist" use-case, so nearby results are  surfaced even if the language is set to a non-local language, instead of preferring features far away that happen to match the language.

The current implementation compares the distance from the proximity points (in tiles) to the raw proximity radius in the match opts (in miles).

This PR updates this comparison to compare apples to apples by converting the proximity radius to tiles. It is slightly duplicative, since the proximity radius also gets converted to tiles in the scoredist function, so there may be opportunities to optimize by only doing the calculation once in the future.


### Real deduping by feature id
The current implementation uses rust's `dedupe_by_key` method in coalesce to "dedupe" contexts with the same grid id. This method requires the vector to be already sorted by the key to properly remove all duplicates, otherwise it only removed duplicates that happen to be next to each other in the vector. An approach similar to this worked in carmen-cache, but in carmen-core, contexts get sorted by relev, scoredist, etc, so it's possible for there to be many grids with the same id in the first several entries, without being next to each other. This was visible in a [carmen test](https://github.com/mapbox/carmen/blob/master/test/acceptance/geocode-unit.proximity-polygon.test.js) for behavior of features that span many tiles. The test indexes 3 features, each spanning several hundred tiles, and expects all three features to be returned in the results. Previously, only two were returned because the first context that had the 3rd grid id was well past the 40 feature cutoff.

This PR uses a hashmap in coalesce single to keep track of grid ids that have already been seen, and replaces the value associated with that id only if a coalesce entry has a higher scoredist and higher or equal relevance.

## Summary of changes
- [x] Convert proximity radius to tiles to properly compare with the distance
- [x] Use a hashmap to keep track of feature ids that have been added to avoid duplicates instead of using `dedupe_by_key`

## Next steps
- [ ] Evaluate whether it's worth a refactor to only do the proximity radius calculation once
- [ ] Assess whether a similar dedupe strategy is necessary for coalesce multi
