### PR TITLE
Reuse ids

### DIFF
--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -79,14 +79,19 @@ fn get_fb_value(value: &mut BuilderEntry) -> Result<Vec<u8>, Error> {
 
     let mut id_lists: Vec<_> = id_lists.into_iter().collect();
     id_lists.sort_by_key(|e| e.1);
-    let fb_id_lists: Vec<_> = id_lists.into_iter().map(|(list, _)| {
-        let list = fb_builder.create_vector(list);
-        IdList::create(&mut fb_builder, &IdListArgs { ids: Some(list) })
-    }).collect();
+    let fb_id_lists: Vec<_> = id_lists
+        .into_iter()
+        .map(|(list, _)| {
+            let list = fb_builder.create_vector(list);
+            IdList::create(&mut fb_builder, &IdListArgs { ids: Some(list) })
+        })
+        .collect();
     let fb_id_lists = fb_builder.create_vector(&fb_id_lists);
 
-    let record =
-        PhraseRecord::create(&mut fb_builder, &PhraseRecordArgs { relev_scores: Some(fb_rses), id_lists: Some(fb_id_lists) });
+    let record = PhraseRecord::create(
+        &mut fb_builder,
+        &PhraseRecordArgs { relev_scores: Some(fb_rses), id_lists: Some(fb_id_lists) },
+    );
     fb_builder.finish(record, None);
     Ok(fb_builder.finished_data().to_vec())
 }

--- a/rust-src/src/gridstore/builder.rs
+++ b/rust-src/src/gridstore/builder.rs
@@ -47,6 +47,10 @@ fn copy_entries(source_entry: &BuilderEntry, destination_entry: &mut BuilderEntr
 fn get_fb_value(value: &mut BuilderEntry) -> Result<Vec<u8>, Error> {
     let mut fb_builder = flatbuffers::FlatBufferBuilder::new();
     let mut rses: Vec<_> = Vec::new();
+
+    let mut id_lists: HashMap<_, u32> = HashMap::new();
+    let mut id_idx = 0;
+
     for (rs, coord_group) in value.iter_mut().rev() {
         let mut coords: Vec<_> = Vec::new();
         for (coord, ids) in coord_group.iter_mut().rev() {
@@ -54,9 +58,14 @@ fn get_fb_value(value: &mut BuilderEntry) -> Result<Vec<u8>, Error> {
             ids.sort_by(|a, b| b.cmp(a));
             ids.dedup();
 
-            let fb_ids = fb_builder.create_vector(&ids);
-            let fb_coord =
-                Coord::create(&mut fb_builder, &CoordArgs { coord: *coord, ids: Some(fb_ids) });
+            let idx = id_lists.entry(ids).or_insert_with(|| {
+                let new_id = id_idx;
+                id_idx += 1;
+                new_id
+            });
+
+            //let fb_ids = fb_builder.create_vector(&ids);
+            let fb_coord = Coord::new(*coord, *idx);
             coords.push(fb_coord);
         }
         let fb_coords = fb_builder.create_vector(&coords);
@@ -67,8 +76,17 @@ fn get_fb_value(value: &mut BuilderEntry) -> Result<Vec<u8>, Error> {
         rses.push(fb_rs);
     }
     let fb_rses = fb_builder.create_vector(&rses);
+
+    let mut id_lists: Vec<_> = id_lists.into_iter().collect();
+    id_lists.sort_by_key(|e| e.1);
+    let fb_id_lists: Vec<_> = id_lists.into_iter().map(|(list, _)| {
+        let list = fb_builder.create_vector(list);
+        IdList::create(&mut fb_builder, &IdListArgs { ids: Some(list) })
+    }).collect();
+    let fb_id_lists = fb_builder.create_vector(&fb_id_lists);
+
     let record =
-        PhraseRecord::create(&mut fb_builder, &PhraseRecordArgs { relev_scores: Some(fb_rses) });
+        PhraseRecord::create(&mut fb_builder, &PhraseRecordArgs { relev_scores: Some(fb_rses), id_lists: Some(fb_id_lists) });
     fb_builder.finish(record, None);
     Ok(fb_builder.finished_data().to_vec())
 }

--- a/rust-src/src/gridstore/gridstore_generated.rs
+++ b/rust-src/src/gridstore/gridstore_generated.rs
@@ -4,8 +4,8 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-use std::mem;
 use std::cmp::Ordering;
+use std::mem;
 
 extern crate flatbuffers;
 use self::flatbuffers::EndianScalar;
@@ -14,23 +14,23 @@ use self::flatbuffers::EndianScalar;
 #[repr(C, align(4))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Coord {
-  coord_: u32,
-  id_list_: u32,
+    coord_: u32,
+    id_list_: u32,
 } // pub struct Coord
 impl flatbuffers::SafeSliceAccess for Coord {}
 impl<'a> flatbuffers::Follow<'a> for Coord {
-  type Inner = &'a Coord;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    <&'a Coord>::follow(buf, loc)
-  }
+    type Inner = &'a Coord;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        <&'a Coord>::follow(buf, loc)
+    }
 }
 impl<'a> flatbuffers::Follow<'a> for &'a Coord {
-  type Inner = &'a Coord;
-  #[inline]
-  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-    flatbuffers::follow_cast_ref::<Coord>(buf, loc)
-  }
+    type Inner = &'a Coord;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        flatbuffers::follow_cast_ref::<Coord>(buf, loc)
+    }
 }
 impl<'b> flatbuffers::Push for Coord {
     type Output = Coord;
@@ -54,293 +54,308 @@ impl<'b> flatbuffers::Push for &'b Coord {
     }
 }
 
-
 impl Coord {
-  pub fn new<'a>(_coord: u32, _id_list: u32) -> Self {
-    Coord {
-      coord_: _coord.to_little_endian(),
-      id_list_: _id_list.to_little_endian(),
-
+    pub fn new<'a>(_coord: u32, _id_list: u32) -> Self {
+        Coord { coord_: _coord.to_little_endian(), id_list_: _id_list.to_little_endian() }
     }
-  }
-  pub fn coord<'a>(&'a self) -> u32 {
-    self.coord_.from_little_endian()
-  }
-  pub fn id_list<'a>(&'a self) -> u32 {
-    self.id_list_.from_little_endian()
-  }
+    pub fn coord<'a>(&'a self) -> u32 {
+        self.coord_.from_little_endian()
+    }
+    pub fn id_list<'a>(&'a self) -> u32 {
+        self.id_list_.from_little_endian()
+    }
 }
 
 pub enum RelevScoreOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct RelevScore<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for RelevScore<'a> {
     type Inner = RelevScore<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
     }
 }
 
 impl<'a> RelevScore<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        RelevScore {
-            _tab: table,
-        }
+        RelevScore { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args RelevScoreArgs<'args>) -> flatbuffers::WIPOffset<RelevScore<'bldr>> {
-      let mut builder = RelevScoreBuilder::new(_fbb);
-      if let Some(x) = args.coords { builder.add_coords(x); }
-      builder.add_relev_score(args.relev_score);
-      builder.finish()
+        args: &'args RelevScoreArgs<'args>,
+    ) -> flatbuffers::WIPOffset<RelevScore<'bldr>> {
+        let mut builder = RelevScoreBuilder::new(_fbb);
+        if let Some(x) = args.coords {
+            builder.add_coords(x);
+        }
+        builder.add_relev_score(args.relev_score);
+        builder.finish()
     }
 
     pub const VT_RELEV_SCORE: flatbuffers::VOffsetT = 4;
     pub const VT_COORDS: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn relev_score(&self) -> u8 {
-    self._tab.get::<u8>(RelevScore::VT_RELEV_SCORE, Some(0)).unwrap()
-  }
-  #[inline]
-  pub fn coords(&self) -> Option<&'a [Coord]> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<Coord>>>(RelevScore::VT_COORDS, None).map(|v| v.safe_slice() )
-  }
+    #[inline]
+    pub fn relev_score(&self) -> u8 {
+        self._tab.get::<u8>(RelevScore::VT_RELEV_SCORE, Some(0)).unwrap()
+    }
+    #[inline]
+    pub fn coords(&self) -> Option<&'a [Coord]> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<Coord>>>(
+                RelevScore::VT_COORDS,
+                None,
+            )
+            .map(|v| v.safe_slice())
+    }
 }
 
 pub struct RelevScoreArgs<'a> {
     pub relev_score: u8,
-    pub coords: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Coord>>>,
+    pub coords: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, Coord>>>,
 }
 impl<'a> Default for RelevScoreArgs<'a> {
     #[inline]
     fn default() -> Self {
-        RelevScoreArgs {
-            relev_score: 0,
-            coords: None,
-        }
+        RelevScoreArgs { relev_score: 0, coords: None }
     }
 }
 pub struct RelevScoreBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> RelevScoreBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_relev_score(&mut self, relev_score: u8) {
-    self.fbb_.push_slot::<u8>(RelevScore::VT_RELEV_SCORE, relev_score, 0);
-  }
-  #[inline]
-  pub fn add_coords(&mut self, coords: flatbuffers::WIPOffset<flatbuffers::Vector<'b , Coord>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(RelevScore::VT_COORDS, coords);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RelevScoreBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    RelevScoreBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_relev_score(&mut self, relev_score: u8) {
+        self.fbb_.push_slot::<u8>(RelevScore::VT_RELEV_SCORE, relev_score, 0);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<RelevScore<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_coords(&mut self, coords: flatbuffers::WIPOffset<flatbuffers::Vector<'b, Coord>>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(RelevScore::VT_COORDS, coords);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RelevScoreBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        RelevScoreBuilder { fbb_: _fbb, start_: start }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<RelevScore<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 pub enum IdListOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct IdList<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for IdList<'a> {
     type Inner = IdList<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
     }
 }
 
 impl<'a> IdList<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        IdList {
-            _tab: table,
-        }
+        IdList { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args IdListArgs<'args>) -> flatbuffers::WIPOffset<IdList<'bldr>> {
-      let mut builder = IdListBuilder::new(_fbb);
-      if let Some(x) = args.ids { builder.add_ids(x); }
-      builder.finish()
+        args: &'args IdListArgs<'args>,
+    ) -> flatbuffers::WIPOffset<IdList<'bldr>> {
+        let mut builder = IdListBuilder::new(_fbb);
+        if let Some(x) = args.ids {
+            builder.add_ids(x);
+        }
+        builder.finish()
     }
 
     pub const VT_IDS: flatbuffers::VOffsetT = 4;
 
-  #[inline]
-  pub fn ids(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(IdList::VT_IDS, None)
-  }
+    #[inline]
+    pub fn ids(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        self._tab
+            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(IdList::VT_IDS, None)
+    }
 }
 
 pub struct IdListArgs<'a> {
-    pub ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u32>>>,
+    pub ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
 impl<'a> Default for IdListArgs<'a> {
     #[inline]
     fn default() -> Self {
-        IdListArgs {
-            ids: None,
-        }
+        IdListArgs { ids: None }
     }
 }
 pub struct IdListBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> IdListBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_ids(&mut self, ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(IdList::VT_IDS, ids);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> IdListBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    IdListBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_ids(&mut self, ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(IdList::VT_IDS, ids);
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<IdList<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> IdListBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        IdListBuilder { fbb_: _fbb, start_: start }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<IdList<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 pub enum PhraseRecordOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct PhraseRecord<'a> {
-  pub _tab: flatbuffers::Table<'a>,
+    pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for PhraseRecord<'a> {
     type Inner = PhraseRecord<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self {
-            _tab: flatbuffers::Table { buf: buf, loc: loc },
-        }
+        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
     }
 }
 
 impl<'a> PhraseRecord<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        PhraseRecord {
-            _tab: table,
-        }
+        PhraseRecord { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args PhraseRecordArgs<'args>) -> flatbuffers::WIPOffset<PhraseRecord<'bldr>> {
-      let mut builder = PhraseRecordBuilder::new(_fbb);
-      if let Some(x) = args.id_lists { builder.add_id_lists(x); }
-      if let Some(x) = args.relev_scores { builder.add_relev_scores(x); }
-      builder.finish()
+        args: &'args PhraseRecordArgs<'args>,
+    ) -> flatbuffers::WIPOffset<PhraseRecord<'bldr>> {
+        let mut builder = PhraseRecordBuilder::new(_fbb);
+        if let Some(x) = args.id_lists {
+            builder.add_id_lists(x);
+        }
+        if let Some(x) = args.relev_scores {
+            builder.add_relev_scores(x);
+        }
+        builder.finish()
     }
 
     pub const VT_RELEV_SCORES: flatbuffers::VOffsetT = 4;
     pub const VT_ID_LISTS: flatbuffers::VOffsetT = 6;
 
-  #[inline]
-  pub fn relev_scores(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<RelevScore<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<RelevScore<'a>>>>>(PhraseRecord::VT_RELEV_SCORES, None)
-  }
-  #[inline]
-  pub fn id_lists(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IdList<'a>>>> {
-    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<IdList<'a>>>>>(PhraseRecord::VT_ID_LISTS, None)
-  }
+    #[inline]
+    pub fn relev_scores(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<RelevScore<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<flatbuffers::ForwardsUOffset<RelevScore<'a>>>,
+        >>(PhraseRecord::VT_RELEV_SCORES, None)
+    }
+    #[inline]
+    pub fn id_lists(
+        &self,
+    ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IdList<'a>>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<
+            flatbuffers::Vector<flatbuffers::ForwardsUOffset<IdList<'a>>>,
+        >>(PhraseRecord::VT_ID_LISTS, None)
+    }
 }
 
 pub struct PhraseRecordArgs<'a> {
-    pub relev_scores: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<RelevScore<'a >>>>>,
-    pub id_lists: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<IdList<'a >>>>>,
+    pub relev_scores: Option<
+        flatbuffers::WIPOffset<
+            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<RelevScore<'a>>>,
+        >,
+    >,
+    pub id_lists: Option<
+        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IdList<'a>>>>,
+    >,
 }
 impl<'a> Default for PhraseRecordArgs<'a> {
     #[inline]
     fn default() -> Self {
-        PhraseRecordArgs {
-            relev_scores: None,
-            id_lists: None,
-        }
+        PhraseRecordArgs { relev_scores: None, id_lists: None }
     }
 }
 pub struct PhraseRecordBuilder<'a: 'b, 'b> {
-  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> PhraseRecordBuilder<'a, 'b> {
-  #[inline]
-  pub fn add_relev_scores(&mut self, relev_scores: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<RelevScore<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(PhraseRecord::VT_RELEV_SCORES, relev_scores);
-  }
-  #[inline]
-  pub fn add_id_lists(&mut self, id_lists: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<IdList<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(PhraseRecord::VT_ID_LISTS, id_lists);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PhraseRecordBuilder<'a, 'b> {
-    let start = _fbb.start_table();
-    PhraseRecordBuilder {
-      fbb_: _fbb,
-      start_: start,
+    #[inline]
+    pub fn add_relev_scores(
+        &mut self,
+        relev_scores: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<RelevScore<'b>>>,
+        >,
+    ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            PhraseRecord::VT_RELEV_SCORES,
+            relev_scores,
+        );
     }
-  }
-  #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<PhraseRecord<'a>> {
-    let o = self.fbb_.end_table(self.start_);
-    flatbuffers::WIPOffset::new(o.value())
-  }
+    #[inline]
+    pub fn add_id_lists(
+        &mut self,
+        id_lists: flatbuffers::WIPOffset<
+            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<IdList<'b>>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(PhraseRecord::VT_ID_LISTS, id_lists);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PhraseRecordBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        PhraseRecordBuilder { fbb_: _fbb, start_: start }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<PhraseRecord<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 #[inline]
 pub fn get_root_as_phrase_record<'a>(buf: &'a [u8]) -> PhraseRecord<'a> {
-  flatbuffers::get_root::<PhraseRecord<'a>>(buf)
+    flatbuffers::get_root::<PhraseRecord<'a>>(buf)
 }
 
 #[inline]
 pub fn get_size_prefixed_root_as_phrase_record<'a>(buf: &'a [u8]) -> PhraseRecord<'a> {
-  flatbuffers::get_size_prefixed_root::<PhraseRecord<'a>>(buf)
+    flatbuffers::get_size_prefixed_root::<PhraseRecord<'a>>(buf)
 }
 
 #[inline]
 pub fn finish_phrase_record_buffer<'a, 'b>(
     fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<PhraseRecord<'a>>) {
-  fbb.finish(root, None);
+    root: flatbuffers::WIPOffset<PhraseRecord<'a>>,
+) {
+    fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_phrase_record_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<PhraseRecord<'a>>) {
-  fbb.finish_size_prefixed(root, None);
+pub fn finish_size_prefixed_phrase_record_buffer<'a, 'b>(
+    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    root: flatbuffers::WIPOffset<PhraseRecord<'a>>,
+) {
+    fbb.finish_size_prefixed(root, None);
 }

--- a/rust-src/src/gridstore/gridstore_generated.rs
+++ b/rust-src/src/gridstore/gridstore_generated.rs
@@ -3,288 +3,344 @@
 
 #![allow(dead_code)]
 #![allow(unused_imports)]
+
+use std::mem;
+use std::cmp::Ordering;
+
 extern crate flatbuffers;
+use self::flatbuffers::EndianScalar;
 
-pub enum CoordOffset {}
-#[derive(Copy, Clone, Debug, PartialEq)]
-
-pub struct Coord<'a> {
-    pub _tab: flatbuffers::Table<'a>,
+// struct Coord, aligned to 4
+#[repr(C, align(4))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Coord {
+  coord_: u32,
+  id_list_: u32,
+} // pub struct Coord
+impl flatbuffers::SafeSliceAccess for Coord {}
+impl<'a> flatbuffers::Follow<'a> for Coord {
+  type Inner = &'a Coord;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    <&'a Coord>::follow(buf, loc)
+  }
 }
-
-impl<'a> flatbuffers::Follow<'a> for Coord<'a> {
-    type Inner = Coord<'a>;
-    #[inline]
-    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
-    }
+impl<'a> flatbuffers::Follow<'a> for &'a Coord {
+  type Inner = &'a Coord;
+  #[inline]
+  fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    flatbuffers::follow_cast_ref::<Coord>(buf, loc)
+  }
 }
-
-impl<'a> Coord<'a> {
+impl<'b> flatbuffers::Push for Coord {
+    type Output = Coord;
     #[inline]
-    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        Coord { _tab: table }
-    }
-    #[allow(unused_mut)]
-    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
-        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args CoordArgs<'args>,
-    ) -> flatbuffers::WIPOffset<Coord<'bldr>> {
-        let mut builder = CoordBuilder::new(_fbb);
-        if let Some(x) = args.ids {
-            builder.add_ids(x);
-        }
-        builder.add_coord(args.coord);
-        builder.finish()
-    }
-
-    pub const VT_COORD: flatbuffers::VOffsetT = 4;
-    pub const VT_IDS: flatbuffers::VOffsetT = 6;
-
-    #[inline]
-    pub fn coord(&self) -> u32 {
-        self._tab.get::<u32>(Coord::VT_COORD, Some(0)).unwrap()
-    }
-    #[inline]
-    pub fn ids(&self) -> Option<flatbuffers::Vector<'a, u32>> {
-        self._tab
-            .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(Coord::VT_IDS, None)
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::std::slice::from_raw_parts(self as *const Coord as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
     }
 }
+impl<'b> flatbuffers::Push for &'b Coord {
+    type Output = Coord;
 
-pub struct CoordArgs<'a> {
-    pub coord: u32,
-    pub ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-}
-impl<'a> Default for CoordArgs<'a> {
     #[inline]
-    fn default() -> Self {
-        CoordArgs { coord: 0, ids: None }
+    fn push(&self, dst: &mut [u8], _rest: &[u8]) {
+        let src = unsafe {
+            ::std::slice::from_raw_parts(*self as *const Coord as *const u8, Self::size())
+        };
+        dst.copy_from_slice(src);
     }
 }
-pub struct CoordBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
-}
-impl<'a: 'b, 'b> CoordBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_coord(&mut self, coord: u32) {
-        self.fbb_.push_slot::<u32>(Coord::VT_COORD, coord, 0);
+
+
+impl Coord {
+  pub fn new<'a>(_coord: u32, _id_list: u32) -> Self {
+    Coord {
+      coord_: _coord.to_little_endian(),
+      id_list_: _id_list.to_little_endian(),
+
     }
-    #[inline]
-    pub fn add_ids(&mut self, ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Coord::VT_IDS, ids);
-    }
-    #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> CoordBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        CoordBuilder { fbb_: _fbb, start_: start }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<Coord<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
+  }
+  pub fn coord<'a>(&'a self) -> u32 {
+    self.coord_.from_little_endian()
+  }
+  pub fn id_list<'a>(&'a self) -> u32 {
+    self.id_list_.from_little_endian()
+  }
 }
 
 pub enum RelevScoreOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct RelevScore<'a> {
-    pub _tab: flatbuffers::Table<'a>,
+  pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for RelevScore<'a> {
     type Inner = RelevScore<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
     }
 }
 
 impl<'a> RelevScore<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        RelevScore { _tab: table }
+        RelevScore {
+            _tab: table,
+        }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args RelevScoreArgs<'args>,
-    ) -> flatbuffers::WIPOffset<RelevScore<'bldr>> {
-        let mut builder = RelevScoreBuilder::new(_fbb);
-        if let Some(x) = args.coords {
-            builder.add_coords(x);
-        }
-        builder.add_relev_score(args.relev_score);
-        builder.finish()
+        args: &'args RelevScoreArgs<'args>) -> flatbuffers::WIPOffset<RelevScore<'bldr>> {
+      let mut builder = RelevScoreBuilder::new(_fbb);
+      if let Some(x) = args.coords { builder.add_coords(x); }
+      builder.add_relev_score(args.relev_score);
+      builder.finish()
     }
 
     pub const VT_RELEV_SCORE: flatbuffers::VOffsetT = 4;
     pub const VT_COORDS: flatbuffers::VOffsetT = 6;
 
-    #[inline]
-    pub fn relev_score(&self) -> u8 {
-        self._tab.get::<u8>(RelevScore::VT_RELEV_SCORE, Some(0)).unwrap()
-    }
-    #[inline]
-    pub fn coords(&self) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord<'a>>>> {
-        self._tab.get::<flatbuffers::ForwardsUOffset<
-            flatbuffers::Vector<flatbuffers::ForwardsUOffset<Coord<'a>>>,
-        >>(RelevScore::VT_COORDS, None)
-    }
+  #[inline]
+  pub fn relev_score(&self) -> u8 {
+    self._tab.get::<u8>(RelevScore::VT_RELEV_SCORE, Some(0)).unwrap()
+  }
+  #[inline]
+  pub fn coords(&self) -> Option<&'a [Coord]> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<Coord>>>(RelevScore::VT_COORDS, None).map(|v| v.safe_slice() )
+  }
 }
 
 pub struct RelevScoreArgs<'a> {
     pub relev_score: u8,
-    pub coords: Option<
-        flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Coord<'a>>>>,
-    >,
+    pub coords: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , Coord>>>,
 }
 impl<'a> Default for RelevScoreArgs<'a> {
     #[inline]
     fn default() -> Self {
-        RelevScoreArgs { relev_score: 0, coords: None }
+        RelevScoreArgs {
+            relev_score: 0,
+            coords: None,
+        }
     }
 }
 pub struct RelevScoreBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> RelevScoreBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_relev_score(&mut self, relev_score: u8) {
-        self.fbb_.push_slot::<u8>(RelevScore::VT_RELEV_SCORE, relev_score, 0);
+  #[inline]
+  pub fn add_relev_score(&mut self, relev_score: u8) {
+    self.fbb_.push_slot::<u8>(RelevScore::VT_RELEV_SCORE, relev_score, 0);
+  }
+  #[inline]
+  pub fn add_coords(&mut self, coords: flatbuffers::WIPOffset<flatbuffers::Vector<'b , Coord>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(RelevScore::VT_COORDS, coords);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RelevScoreBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    RelevScoreBuilder {
+      fbb_: _fbb,
+      start_: start,
     }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<RelevScore<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+pub enum IdListOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct IdList<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for IdList<'a> {
+    type Inner = IdList<'a>;
     #[inline]
-    pub fn add_coords(
-        &mut self,
-        coords: flatbuffers::WIPOffset<
-            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Coord<'b>>>,
-        >,
-    ) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(RelevScore::VT_COORDS, coords);
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
     }
+}
+
+impl<'a> IdList<'a> {
     #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> RelevScoreBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        RelevScoreBuilder { fbb_: _fbb, start_: start }
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        IdList {
+            _tab: table,
+        }
     }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args IdListArgs<'args>) -> flatbuffers::WIPOffset<IdList<'bldr>> {
+      let mut builder = IdListBuilder::new(_fbb);
+      if let Some(x) = args.ids { builder.add_ids(x); }
+      builder.finish()
+    }
+
+    pub const VT_IDS: flatbuffers::VOffsetT = 4;
+
+  #[inline]
+  pub fn ids(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(IdList::VT_IDS, None)
+  }
+}
+
+pub struct IdListArgs<'a> {
+    pub ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a ,  u32>>>,
+}
+impl<'a> Default for IdListArgs<'a> {
     #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<RelevScore<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
+    fn default() -> Self {
+        IdListArgs {
+            ids: None,
+        }
     }
+}
+pub struct IdListBuilder<'a: 'b, 'b> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> IdListBuilder<'a, 'b> {
+  #[inline]
+  pub fn add_ids(&mut self, ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(IdList::VT_IDS, ids);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> IdListBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    IdListBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<IdList<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
 }
 
 pub enum PhraseRecordOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct PhraseRecord<'a> {
-    pub _tab: flatbuffers::Table<'a>,
+  pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for PhraseRecord<'a> {
     type Inner = PhraseRecord<'a>;
     #[inline]
     fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        Self { _tab: flatbuffers::Table { buf: buf, loc: loc } }
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
     }
 }
 
 impl<'a> PhraseRecord<'a> {
     #[inline]
     pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        PhraseRecord { _tab: table }
+        PhraseRecord {
+            _tab: table,
+        }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args PhraseRecordArgs<'args>,
-    ) -> flatbuffers::WIPOffset<PhraseRecord<'bldr>> {
-        let mut builder = PhraseRecordBuilder::new(_fbb);
-        if let Some(x) = args.relev_scores {
-            builder.add_relev_scores(x);
-        }
-        builder.finish()
+        args: &'args PhraseRecordArgs<'args>) -> flatbuffers::WIPOffset<PhraseRecord<'bldr>> {
+      let mut builder = PhraseRecordBuilder::new(_fbb);
+      if let Some(x) = args.id_lists { builder.add_id_lists(x); }
+      if let Some(x) = args.relev_scores { builder.add_relev_scores(x); }
+      builder.finish()
     }
 
     pub const VT_RELEV_SCORES: flatbuffers::VOffsetT = 4;
+    pub const VT_ID_LISTS: flatbuffers::VOffsetT = 6;
 
-    #[inline]
-    pub fn relev_scores(
-        &self,
-    ) -> Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<RelevScore<'a>>>> {
-        self._tab.get::<flatbuffers::ForwardsUOffset<
-            flatbuffers::Vector<flatbuffers::ForwardsUOffset<RelevScore<'a>>>,
-        >>(PhraseRecord::VT_RELEV_SCORES, None)
-    }
+  #[inline]
+  pub fn relev_scores(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<RelevScore<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<RelevScore<'a>>>>>(PhraseRecord::VT_RELEV_SCORES, None)
+  }
+  #[inline]
+  pub fn id_lists(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IdList<'a>>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<IdList<'a>>>>>(PhraseRecord::VT_ID_LISTS, None)
+  }
 }
 
 pub struct PhraseRecordArgs<'a> {
-    pub relev_scores: Option<
-        flatbuffers::WIPOffset<
-            flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<RelevScore<'a>>>,
-        >,
-    >,
+    pub relev_scores: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<RelevScore<'a >>>>>,
+    pub id_lists: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<IdList<'a >>>>>,
 }
 impl<'a> Default for PhraseRecordArgs<'a> {
     #[inline]
     fn default() -> Self {
-        PhraseRecordArgs { relev_scores: None }
+        PhraseRecordArgs {
+            relev_scores: None,
+            id_lists: None,
+        }
     }
 }
 pub struct PhraseRecordBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> PhraseRecordBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_relev_scores(
-        &mut self,
-        relev_scores: flatbuffers::WIPOffset<
-            flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<RelevScore<'b>>>,
-        >,
-    ) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-            PhraseRecord::VT_RELEV_SCORES,
-            relev_scores,
-        );
+  #[inline]
+  pub fn add_relev_scores(&mut self, relev_scores: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<RelevScore<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(PhraseRecord::VT_RELEV_SCORES, relev_scores);
+  }
+  #[inline]
+  pub fn add_id_lists(&mut self, id_lists: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<IdList<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(PhraseRecord::VT_ID_LISTS, id_lists);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PhraseRecordBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    PhraseRecordBuilder {
+      fbb_: _fbb,
+      start_: start,
     }
-    #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> PhraseRecordBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        PhraseRecordBuilder { fbb_: _fbb, start_: start }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<PhraseRecord<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        flatbuffers::WIPOffset::new(o.value())
-    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<PhraseRecord<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
 }
 
 #[inline]
 pub fn get_root_as_phrase_record<'a>(buf: &'a [u8]) -> PhraseRecord<'a> {
-    flatbuffers::get_root::<PhraseRecord<'a>>(buf)
+  flatbuffers::get_root::<PhraseRecord<'a>>(buf)
 }
 
 #[inline]
 pub fn get_size_prefixed_root_as_phrase_record<'a>(buf: &'a [u8]) -> PhraseRecord<'a> {
-    flatbuffers::get_size_prefixed_root::<PhraseRecord<'a>>(buf)
+  flatbuffers::get_size_prefixed_root::<PhraseRecord<'a>>(buf)
 }
 
 #[inline]
 pub fn finish_phrase_record_buffer<'a, 'b>(
     fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<PhraseRecord<'a>>,
-) {
-    fbb.finish(root, None);
+    root: flatbuffers::WIPOffset<PhraseRecord<'a>>) {
+  fbb.finish(root, None);
 }
 
 #[inline]
-pub fn finish_size_prefixed_phrase_record_buffer<'a, 'b>(
-    fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    root: flatbuffers::WIPOffset<PhraseRecord<'a>>,
-) {
-    fbb.finish_size_prefixed(root, None);
+pub fn finish_size_prefixed_phrase_record_buffer<'a, 'b>(fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>, root: flatbuffers::WIPOffset<PhraseRecord<'a>>) {
+  fbb.finish_size_prefixed(root, None);
 }

--- a/rust-src/src/gridstore/schema/gridstore.fbs
+++ b/rust-src/src/gridstore/schema/gridstore.fbs
@@ -1,6 +1,6 @@
-table Coord {
+struct Coord {
     coord: uint32;
-    ids: [uint32];
+    id_list: uint32;
 }
 
 table RelevScore {
@@ -8,8 +8,13 @@ table RelevScore {
     coords: [Coord];
 }
 
+table IdList {
+    ids: [uint32];
+}
+
 table PhraseRecord {
     relev_scores: [RelevScore];
+    id_lists: [IdList];
 }
 
 root_type PhraseRecord;

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -7,10 +7,7 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 ///
 /// Returns (Some(min,max)) if the Coord Vector morton order range overlaps with the bounding box,
 /// [`None`] if the Coord Vector morton order range does not overlaps with the bounding box
-pub fn bbox_range<'a>(
-    coords: &'a [Coord],
-    bbox: [u16; 4],
-) -> Option<(u32, u32)> {
+pub fn bbox_range<'a>(coords: &'a [Coord], bbox: [u16; 4]) -> Option<(u32, u32)> {
     let min = interleave_morton(bbox[0], bbox[1]);
     let max = interleave_morton(bbox[2], bbox[3]);
     debug_assert!(min <= max, "Invalid bounding box");
@@ -132,8 +129,8 @@ pub fn bbox_proximity_filter<'a>(
         };
     };
 
-    let head =
-        Box::new((range.0..prox_mid).rev().filter_map(filtered_get)) as Box<Iterator<Item = &'a Coord>>;
+    let head = Box::new((range.0..prox_mid).rev().filter_map(filtered_get))
+        as Box<Iterator<Item = &'a Coord>>;
     let tail =
         Box::new((prox_mid..=range.1).filter_map(filtered_get)) as Box<Iterator<Item = &'a Coord>>;
     let coord_sets = vec![head, tail].into_iter().kmerge_by(move |a, b| {
@@ -152,11 +149,7 @@ pub fn bbox_proximity_filter<'a>(
 /// index of the matching element. If the value is less than the first element and greater than the last,
 /// [`Result::Ok'] is returned containing either 0 or the length of the Vector. A ['Results:Err'] is
 /// returned if the offset is greater to the vector length.
-fn coord_binary_search<'a>(
-    coords: &'a [Coord],
-    val: u32,
-    offset: u32,
-) -> Result<u32, &'a str> {
+fn coord_binary_search<'a>(coords: &'a [Coord], val: u32, offset: u32) -> Result<u32, &'a str> {
     let len = coords.len() as u32;
 
     if offset >= len {

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -145,9 +145,16 @@ fn decode_value<T: AsRef<[u8]>>(value: T) -> impl Iterator<Item = GridEntry> {
         (value, static_ref)
     };
     let record = get_root_as_phrase_record(record_ref.1);
-    let rs_vec =
-        get_vector::<RelevScore>(record_ref.1, &record._tab, PhraseRecord::VT_RELEV_SCORES)
-            .unwrap();
+    let rs_vec = get_vector::<RelevScore>(
+        record_ref.1,
+        &record._tab,
+        PhraseRecord::VT_RELEV_SCORES,
+    ).unwrap();
+    let id_vec = get_vector::<IdList>(
+        record_ref.1,
+        &record._tab,
+        PhraseRecord::VT_ID_LISTS,
+    ).unwrap();
 
     let iter = rs_vec.iter().flat_map(move |rs_obj| {
         let relev_score = rs_obj.relev_score();
@@ -155,13 +162,15 @@ fn decode_value<T: AsRef<[u8]>>(value: T) -> impl Iterator<Item = GridEntry> {
         // mask for the least significant four bits
         let score = relev_score & 15;
 
-        let coords =
-            get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS).unwrap();
+        let coords = rs_obj.coords().unwrap();
 
         coords.into_iter().flat_map(move |coords_obj| {
             let (x, y) = deinterleave_morton(coords_obj.coord());
+            let id_list_idx = coords_obj.id_list() as usize;
 
-            coords_obj.ids().unwrap().iter().map(move |id_comp| {
+            let ids = id_vec.get(id_list_idx).ids();
+
+            ids.unwrap().iter().map(move |id_comp| {
                 let id = id_comp >> 8;
                 let source_phrase_hash = (id_comp & 255) as u8;
                 GridEntry { relev, score, x, y, id, source_phrase_hash }
@@ -182,6 +191,7 @@ impl GridStore {
         Ok(GridStore { db, path })
     }
 
+    #[inline(never)]
     pub fn get(&self, key: &GridKey) -> Result<Option<impl Iterator<Item = GridEntry>>, Error> {
         let mut db_key: Vec<u8> = Vec::new();
         key.write_to(0, &mut db_key)?;
@@ -193,6 +203,7 @@ impl GridStore {
     }
 
     // this is only called this because of inertia -- I'm open to a rename
+    #[inline(never)]
     pub fn get_matching(
         &self,
         match_key: &MatchKey,
@@ -253,6 +264,9 @@ impl GridStore {
             let rs_vec =
                 get_vector::<RelevScore>(record_ref.1, &record._tab, PhraseRecord::VT_RELEV_SCORES)
                     .unwrap();
+            let id_list_vec =
+                get_vector::<IdList>(record_ref.1, &record._tab, PhraseRecord::VT_ID_LISTS)
+                    .unwrap();
 
             let matches_language = record_ref.2;
 
@@ -262,31 +276,30 @@ impl GridStore {
                 // mask for the least significant four bits
                 let score = relev_score & 15;
 
-                let coords_vec =
-                    get_vector::<Coord>(record_ref.1, &rs_obj._tab, RelevScore::VT_COORDS).unwrap();
+                let coords_vec = rs_obj.coords().unwrap();
                 // TODO could this be a reference? The compiler was saying:
                 // "cannot move out of captured variable in an `FnMut` closure"
                 // "help: consider borrowing here: `&match_opts`rustc(E0507)""
                 let coords = match &match_opts {
                     MatchOpts { bbox: None, proximity: None, .. } => {
-                        Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = Coord>>)
+                        Some(Box::new(coords_vec.into_iter()) as Box<Iterator<Item = &Coord>>)
                     }
                     MatchOpts { bbox: Some(bbox), proximity: None, .. } => {
                         // TODO should the bbox argument be changed to a reference in bbox? The compiler was complaining
                         match spatial::bbox_filter(coords_vec, *bbox) {
-                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
+                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = &Coord>>),
                             None => None,
                         }
                     }
                     MatchOpts { bbox: None, proximity: Some(prox_pt), .. } => {
                         match spatial::proximity(coords_vec, prox_pt.point) {
-                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
+                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = &Coord>>),
                             None => None,
                         }
                     }
                     MatchOpts { bbox: Some(bbox), proximity: Some(prox_pt), .. } => {
                         match spatial::bbox_proximity_filter(coords_vec, *bbox, prox_pt.point) {
-                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = Coord>>),
+                            Some(v) => Some(Box::new(v) as Box<Iterator<Item = &Coord>>),
                             None => None,
                         }
                     }
@@ -295,13 +308,14 @@ impl GridStore {
                 if coords.is_some() {
                     let slot =
                         coords_for_relev.entry(OrderedFloat(relev)).or_insert_with(|| vec![]);
-                    slot.push((score, matches_language, coords.unwrap()));
+                    slot.push((score, matches_language, coords.unwrap(), id_list_vec.clone()));
                 }
             }
         }
 
         struct SortGroup<'a> {
-            coords: Coord<'a>,
+            coords: Coord,
+            id_lists: flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<IdList<'a>>>,
             scoredist: f64,
             x: u16,
             y: u16,
@@ -321,7 +335,7 @@ impl GridStore {
             // for each relev/score, lazily k-way-merge the child entities by z-order curve value
             let merged = coord_sets
                 .into_iter()
-                .map(move |(score, matches_language, coord_vec)| {
+                .map(move |(score, matches_language, coord_vec, id_lists)| {
                     let match_opts = match_opts.clone();
                     coord_vec.map(move |coords| {
                         let coord = coords.coord();
@@ -341,7 +355,8 @@ impl GridStore {
                             _ => (0f64, false, score as f64),
                         };
                         SortGroup {
-                            coords,
+                            coords: *coords,
+                            id_lists,
                             scoredist,
                             x,
                             y,
@@ -375,14 +390,20 @@ impl GridStore {
                         1 => {
                             score = coords_obj_group[0].score;
                             distance = coords_obj_group[0].distance;
-                            coords_obj_group[0].coords.ids().unwrap().iter().collect()
+
+                            let id_list_idx = coords_obj_group[0].coords.id_list() as usize;
+                            let ids = coords_obj_group[0].id_lists.get(id_list_idx).ids();
+
+                            ids.unwrap().iter().collect()
                         }
                         _ => {
                             let mut ids = Vec::new();
                             score = coords_obj_group[0].score;
                             distance = coords_obj_group[0].distance;
                             for group in coords_obj_group {
-                                ids.extend(group.coords.ids().unwrap().iter());
+                                let id_list_idx = group.coords.id_list() as usize;
+                                let fb_ids = group.id_lists.get(id_list_idx).ids();
+                                ids.extend(fb_ids.unwrap().iter());
                             }
                             ids.sort_by(|a, b| b.cmp(a));
                             ids.dedup();

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -145,16 +145,11 @@ fn decode_value<T: AsRef<[u8]>>(value: T) -> impl Iterator<Item = GridEntry> {
         (value, static_ref)
     };
     let record = get_root_as_phrase_record(record_ref.1);
-    let rs_vec = get_vector::<RelevScore>(
-        record_ref.1,
-        &record._tab,
-        PhraseRecord::VT_RELEV_SCORES,
-    ).unwrap();
-    let id_vec = get_vector::<IdList>(
-        record_ref.1,
-        &record._tab,
-        PhraseRecord::VT_ID_LISTS,
-    ).unwrap();
+    let rs_vec =
+        get_vector::<RelevScore>(record_ref.1, &record._tab, PhraseRecord::VT_RELEV_SCORES)
+            .unwrap();
+    let id_vec =
+        get_vector::<IdList>(record_ref.1, &record._tab, PhraseRecord::VT_ID_LISTS).unwrap();
 
     let iter = rs_vec.iter().flat_map(move |rs_obj| {
         let relev_score = rs_obj.relev_score();

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -152,6 +152,9 @@ fn decode_value<T: AsRef<[u8]>>(value: T) -> impl Iterator<Item = GridEntry> {
         get_vector::<IdList>(record_ref.1, &record._tab, PhraseRecord::VT_ID_LISTS).unwrap();
 
     let iter = rs_vec.iter().flat_map(move |rs_obj| {
+        // grab a reference to the outer object to make sure it doesn't get freed
+        let _ref = &record_ref;
+
         let relev_score = rs_obj.relev_score();
         let relev = relev_int_to_float(relev_score >> 4);
         // mask for the least significant four bits


### PR DESCRIPTION
This PR changes the Flatbuffers format for carmen-core to take advantage of the fact that it's often the case, particular with polygonal features, for many X/Y entries for the same phrase to map to the same ID or list of IDs. It hoists these lists of IDs up to a unique-ified top-level list (so, a list of lists of IDs), and then changes the format for the object that *was* `{x, y, [id]}` to be `{x, y, id_idx}`, where the last field is an index into the aforementioned list of lists. This both lets us dedupe these ID lists, and lets us store this x/y/ids object as a Flatbuffers struct instead of a table, which eliminates an extra layer of indirection.