### PR TITLE
Variable prefix bins [wip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-custom-format-1",
+  "version": "0.1.0-variable-bins-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -394,11 +394,11 @@ pub fn relev_int_to_float(relev: u8) -> f64 {
 // the itertools version
 pub fn somewhat_eager_groupby<T: Iterator, F, K>(
     mut it: T,
-    key: F,
+    mut key: F,
 ) -> impl Iterator<Item = (K, Vec<T::Item>)>
 where
     K: Sized + Copy + PartialEq,
-    F: Fn(&T::Item) -> K,
+    F: FnMut(&T::Item) -> K,
 {
     let mut curr_key: Option<K> = None;
     let mut running_group: Vec<T::Item> = Vec::new();

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -42,6 +42,13 @@ pub struct StoreEntryBuildingBlock {
     pub entries: Vec<GridEntry>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct PrefixBoundary {
+    prefix: String,
+    first: u32,
+    last: u32
+}
+
 /// Utility to create stores
 /// Takes an vector, with each item mapping to a store to create
 /// Each item is a vector with maps of grid keys to the entries to insert into the store for that grid key
@@ -70,10 +77,10 @@ pub fn load_db_from_json(json_path: &str, store_path: &str) {
     let f = File::open(path).expect("Error opening file");
     let file = io::BufReader::new(f);
 
-    load_db_from_json_reader(file, store_path);
+    load_db_from_json_reader(file, None, store_path);
 }
 
-fn load_db_from_json_reader<T: BufRead>(json_source: T, store_path: &str) {
+fn load_db_from_json_reader<T: BufRead>(json_source: T, split_source: Option<T>, store_path: &str) {
     // Set up new gridstore
     let directory = Path::new(store_path);
     let mut builder = GridStoreBuilder::new(directory).unwrap();
@@ -87,6 +94,19 @@ fn load_db_from_json_reader<T: BufRead>(json_source: T, store_path: &str) {
                 .expect("Unable to insert");
         }
     });
+
+    if let Some(splits) = split_source {
+        let boundary_records: Vec<PrefixBoundary> = splits.lines().map(|l| {
+            serde_json::from_str(&l.unwrap()).expect("Error deserializing json from string")
+        }).collect();
+
+        if boundary_records.len() > 0 {
+            let mut boundaries: Vec<u32> = boundary_records.iter().map(|r| r.first).collect();
+            boundaries.push(boundary_records.last().unwrap().last + 1);
+            builder.load_bin_boundaries(boundaries).unwrap();
+        }
+    }
+
     builder.finish().unwrap();
 }
 
@@ -136,10 +156,16 @@ pub fn ensure_store(datafile: &str) -> PathBuf {
     std::fs::create_dir_all(&tmp).unwrap();
     let idx_path = tmp.join(Path::new(&datafile.replace(".dat.lz4", ".rocksdb")));
     if !idx_path.exists() {
-        let dl_path = ensure_downloaded(datafile);
-        let decoder = Decoder::new(File::open(dl_path).unwrap()).unwrap();
-        let file = io::BufReader::new(decoder);
-        load_db_from_json_reader(file, idx_path.to_str().unwrap());
+        let grid_path = ensure_downloaded(datafile);
+        let splits_path = ensure_downloaded(&datafile.replace(".gridstore.dat.lz4", ".splits.lz4"));
+
+        let grid_decoder = Decoder::new(File::open(grid_path).unwrap()).unwrap();
+        let grid_file = io::BufReader::new(grid_decoder);
+
+        let splits_decoder = Decoder::new(File::open(splits_path).unwrap()).unwrap();
+        let splits_file = io::BufReader::new(splits_decoder);
+
+        load_db_from_json_reader(grid_file, Some(splits_file), idx_path.to_str().unwrap());
     }
 
     idx_path


### PR DESCRIPTION
#41 introduced a mechanism for pre-combining the grids corresponding to ranges of phrase IDs so that autocomplete scans of large ranges of IDs could combine their contents more efficiently. It turns out in practice that the strategy introduced there was too slow. It created fixed-size bins of ID ranges to precombine (1024 phrases apiece), and would assemble sets of buffers to read for an autocomplete query by scanning individual phrase entries up until the next precombined bin start boundary, then reading from the precombined bins for awhile until the end boundary of the last precombined bin that fit fully within the sought range, then reading individual phrases again until the end of the sought range.

This meant potentially lots of individual phrase reads, as many as three different database seeks per get_matching call, and the existence of at least some bins that could never be used in practice, because they might contain multiple phrases that didn't actually contain any real textual prefixes. The whole thing seems to be a regression from carmen-cache where bin boundaries correspond tightly with actual textual query prefixes, but unlike carmen-cache, carmen-core doesn't know what actual text corresponds to each phrase ID.

This branch ditches the fixed-size bins in favor of a mechanism to allow external callers to specify custom bin boundaries (that presumably correspond with actual text prefixes). These boundaries are then used to generate variably sized bins, and are then stored in a special key in the database for later retrieval, and are then retrieved at index load time and used at query time. There are some benchmarks as well with manually specified boundaries for our sample datasets.

Note: the mechanism for actually splitting a range of phrases into sensibly sized bins is not specified here, and will be up to outside callers to implement.