### PR TITLE
Nocomp Acadia

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-carmen-core",
-  "version": "0.1.0-nocomp-1",
+  "version": "0.1.0-nocomp-acadia-3",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Changes:
* Fix performance issue where there are a large number of entries in a few number of tiles in the coalesce_multi pathway
* This operates by only adding to the coalesced map after the stack entry has been evaluated to prevent it from being compared to its self.

Cause of Issue:
Canadian postcodes are of the form `[A-Z0-9]{6}` for example `M12412` or something similar. In the case of a query like `Acadia M`, the `M` can autocomplete to almost 100k Canadian postcodes which are all within a few small vector tiles.  If this sort of pattern of many elements in a few vector tile locations exists as part of a multi element stack, each of these elements will get compared many unnecessary additional times.  In this case, we did 420,459,007 entries into a loop that contained two if statements.  This cause a massive latency in these queries.  Since a stack element doesn't coalesce with itself, these can be added to the the larger map after the stack element has been evaluated.  This prevents elements from being compared to themselves or other elements from the same stack entry.