### PR TITLE
Use Tarpaulin for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,15 @@ matrix:
       sudo: required
       dist: xenial
       cache: cargo
-      rust: stable
-
-      before_install:
-      - sudo add-apt-repository ppa:sivakov512/kcov -y
-      - sudo apt-get update -q
-      - sudo apt-get install kcov
+      rust:
+        - stable
+        - nightly
 
       before_script:
       - rustup component add rustfmt
 
       before_cache:
-      - cargo install cargo-kcov -f
+      - cargo install cargo-tarpaulin -f
 
       script:
       - cargo clean
@@ -24,7 +21,7 @@ matrix:
       - cargo test
 
       after_success: |
-        cargo kcov
+        cargo tarpaulin --out Xml
         bash <(curl -s https://codecov.io/bash)
 
     - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       dist: xenial
       cache: cargo
       rust:
-        - stable
-        - nightly
         - beta
 
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       - rustup component add rustfmt
 
       before_cache:
-      - cargo install cargo-tarpaulin -f
+      - cargo install cargo-tarpaulin
 
       script:
       - cargo clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       rust:
         - stable
         - nightly
+        - beta
 
       before_script:
       - rustup component add rustfmt

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mapbox/carmen-core.svg?branch=master)](https://travis-ci.org/mapbox/carmen-core)
+
 ## carmen-core
 Carmen-core is a backend storage library for [Carmen](https://github.com/mapbox/carmen) written in Rust. This repository contains both a Rust library (in `rust-src`) and a Javascript wrapper around that library (in `index.js` and `native`).
 
@@ -74,4 +76,3 @@ cargo bench
 Html reports will be generated in `target/criterion/report/index.html`
 
 Criterion will measure the statistical significance of the difference between two different bench runs, so to measure the impact of a change, you can checkout master, run a bench, and then check out a feature branch and run a bench. Note: the results are sensitive to other resource usage on your machine. For more accurate results, run in an isolated environment.
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mapbox/carmen-core.svg?branch=master)](https://travis-ci.org/mapbox/carmen-core)
+[![codecov](https://codecov.io/gh/mapbox/carmen-core/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/carmen-core)
 
 ## carmen-core
 Carmen-core is a backend storage library for [Carmen](https://github.com/mapbox/carmen) written in Rust. This repository contains both a Rust library (in `rust-src`) and a Javascript wrapper around that library (in `index.js` and `native`).


### PR DESCRIPTION
### Context
We've been using kcov for code coverage since previous attempts at using Tarpaulin would crash tests. There have been a couple of releases since the last time we tried using Tarpaulin and we wanted to give the integration another go. This PR attempts to add Tarpaulin and remove kcov.


cc @apendleton @CyanRook @Nmargolis 