### PR TITLE
Add more tests for the variable-bins/bin-boundaries logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mapbox/cfn-config": "^2.15.0",
     "@mapbox/cloudfriend": "^1.9.1",
     "codecov": "^3.3.0",
+    "d3-queue": "^3.0.7",
     "neon-cli": "^0.2.0",
     "nyc": "^14.0.0",
     "tape": "^4.10.2"

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -154,13 +154,13 @@ fn coalesce_single<T: Borrow<GridStore> + Clone>(
         .collect();
 
     contexts.sort_by_key(|context| {
-        (
-            Reverse(OrderedFloat(context.relev)),
-            Reverse(OrderedFloat(context.entries[0].scoredist)),
-            context.entries[0].grid_entry.id,
+        Reverse((
+            OrderedFloat(context.relev),
+            OrderedFloat(context.entries[0].scoredist),
             context.entries[0].grid_entry.x,
             context.entries[0].grid_entry.y,
-        )
+            context.entries[0].grid_entry.id,
+        ))
     });
 
     contexts.truncate(MAX_CONTEXTS);
@@ -311,9 +311,9 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
             Reverse(OrderedFloat(context.relev)),
             Reverse(OrderedFloat(context.entries[0].scoredist)),
             context.entries[0].idx,
-            context.entries[0].grid_entry.id,
-            context.entries[0].grid_entry.x,
-            context.entries[0].grid_entry.y,
+            Reverse(context.entries[0].grid_entry.x),
+            Reverse(context.entries[0].grid_entry.y),
+            Reverse(context.entries[0].grid_entry.id),
         )
     });
 

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -595,7 +595,6 @@ mod tests {
         assert_eq!(records_with_boundaries, expected);
         assert_eq!(records_without_boundaries, expected);
 
-        println!("{:?} {:?}", starts_with_b, starts_with_bc);
         // try via coalesce, comparing the two backends
         let results = vec![
             (&reader_with_boundaries, &starts_with_b),

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -454,8 +454,10 @@ mod tests {
         let directory_with_boundaries: tempfile::TempDir = tempfile::tempdir().unwrap();
         let directory_without_boundaries: tempfile::TempDir = tempfile::tempdir().unwrap();
 
-        let mut builder_with_boundaries = GridStoreBuilder::new(directory_with_boundaries.path()).unwrap();
-        let mut builder_without_boundaries = GridStoreBuilder::new(directory_without_boundaries.path()).unwrap();
+        let mut builder_with_boundaries =
+            GridStoreBuilder::new(directory_with_boundaries.path()).unwrap();
+        let mut builder_without_boundaries =
+            GridStoreBuilder::new(directory_without_boundaries.path()).unwrap();
 
         // this will produce 5000 phrases aaa, aab, aac, ...
         let alphabet = "abcdefghijklmnopqrstuvwxyz";
@@ -481,7 +483,9 @@ mod tests {
                 source_phrase_hash: 0,
             }];
             builder_with_boundaries.insert(&key, entries.clone()).expect("Unable to insert record");
-            builder_without_boundaries.insert(&key, entries.clone()).expect("Unable to insert record");
+            builder_without_boundaries
+                .insert(&key, entries.clone())
+                .expect("Unable to insert record");
         }
 
         // calculate bins
@@ -499,7 +503,8 @@ mod tests {
         builder_without_boundaries.finish().unwrap();
 
         let reader_with_boundaries = GridStore::new(directory_with_boundaries.path()).unwrap();
-        let reader_without_boundaries = GridStore::new(directory_without_boundaries.path()).unwrap();
+        let reader_without_boundaries =
+            GridStore::new(directory_without_boundaries.path()).unwrap();
 
         let find_range = |prefix: &str| {
             let start = phrases
@@ -600,12 +605,17 @@ mod tests {
             (&reader_with_boundaries, &starts_with_b),
             (&reader_without_boundaries, &starts_with_b),
             (&reader_with_boundaries, &starts_with_bc),
-            (&reader_without_boundaries, &starts_with_bc)
-        ].into_iter().map(|(reader, range)| {
+            (&reader_without_boundaries, &starts_with_bc),
+        ]
+        .into_iter()
+        .map(|(reader, range)| {
             let subquery = PhrasematchSubquery {
                 store: reader,
                 weight: 1.,
-                match_key: MatchKey { match_phrase: MatchPhrase::Range { start: range.0, end: range.1 }, lang_set: 1 },
+                match_key: MatchKey {
+                    match_phrase: MatchPhrase::Range { start: range.0, end: range.1 },
+                    lang_set: 1,
+                },
                 idx: 1,
                 zoom: 14,
                 mask: 1 << 0,
@@ -617,7 +627,8 @@ mod tests {
                 ..MatchOpts::default()
             };
             coalesce(stack, &match_opts).unwrap()
-        }).collect::<Vec<_>>();
+        })
+        .collect::<Vec<_>>();
 
         // the starts_with_b ones should be the same
         assert_eq!(results[0], results[1]);

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -530,19 +530,19 @@ fn coalesce_single_languages_test() {
     {
         assert_eq!(result.len(), 4, "Returns 4 results");
         assert_eq!(result[0].relev, 1., "1st result has relevance of 1");
-        assert_eq!(result[0].entries[0].grid_entry.id, 0, "1st result has lowest grid id, which is the tiebreaker for sorting");
+        assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st result has highest grid id, which is the tiebreaker for sorting");
         assert_eq!(result[0].entries[0].grid_entry.relev, 1., "1st result grid has original relevance");
         assert_eq!(result[0].entries[0].matches_language, true, "1st result matches language");
         assert_eq!(result[1].relev, 1., "2nd result has original relevance");
-        assert_eq!(result[1].entries[0].grid_entry.id, 1, "2nd result is the 2nd highest grid id");
+        assert_eq!(result[1].entries[0].grid_entry.id, 2, "2nd result is the 2nd highest grid id");
         assert_eq!(result[1].entries[0].grid_entry.relev, 1., "2nd result grid has original relevance");
         assert_eq!(result[1].entries[0].matches_language, true, "2nd result matches language");
         assert_eq!(result[2].relev, 1., "3rd result has original relevance");
-        assert_eq!(result[2].entries[0].grid_entry.id, 2, "3rd result is the 3rd highest grid id");
+        assert_eq!(result[2].entries[0].grid_entry.id, 1, "3rd result is the 3rd highest grid id");
         assert_eq!(result[2].entries[0].grid_entry.relev, 1., "3rd result grid has original relevance");
         assert_eq!(result[2].entries[0].matches_language, true, "3rd result matches language");
         assert_eq!(result[3].relev, 1., "4th result has original relevance");
-        assert_eq!(result[3].entries[0].grid_entry.id, 3, "4th result is the 4th highest grid id");
+        assert_eq!(result[3].entries[0].grid_entry.id, 0, "4th result is the 4th highest grid id");
         assert_eq!(result[3].entries[0].grid_entry.relev, 1., "4th result grid has original relevance");
         assert_eq!(result[3].entries[0].matches_language, true, "4th result matches language");
     }
@@ -568,19 +568,19 @@ fn coalesce_single_languages_test() {
     {
         assert_eq!(result.len(), 4, "Returns 4 results");
         assert_eq!(result[0].relev, 1., "1st result has relevance of 1");
-        assert_eq!(result[0].entries[0].grid_entry.id, 0, "1st result is a grid with 0 in the lang set, and lowest grid id");
+        assert_eq!(result[0].entries[0].grid_entry.id, 2, "1st result is a grid with 0 in the lang set, and highest grid id");
         assert_eq!(result[0].entries[0].grid_entry.relev, 1., "1st result grid has original relevance");
         assert_eq!(result[0].entries[0].matches_language, true, "1st result matches language");
         assert_eq!(result[1].relev, 1., "2nd result has original relevance");
-        assert_eq!(result[1].entries[0].grid_entry.id, 2, "2nd result is a grid with 0 in the lang set");
+        assert_eq!(result[1].entries[0].grid_entry.id, 0, "2nd result is a grid with 0 in the lang set");
         assert_eq!(result[1].entries[0].grid_entry.relev, 1., "2nd result grid has original relevance");
         assert_eq!(result[1].entries[0].matches_language, true, "2nd result matches language");
         assert_eq!(result[2].relev, 0.96, "3rd result has reduced relevance");
-        assert_eq!(result[2].entries[0].grid_entry.id, 1, "3rd result is a grid that doesnt include lang 0");
+        assert_eq!(result[2].entries[0].grid_entry.id, 3, "3rd result is a grid that doesnt include lang 0");
         assert_eq!(result[2].entries[0].grid_entry.relev, 0.96, "3rd result grid has reduced relevance");
         assert_eq!(result[2].entries[0].matches_language, false, "3rd result does not match language");
         assert_eq!(result[3].relev, 0.96, "4th result has reduced relevance");
-        assert_eq!(result[3].entries[0].grid_entry.id, 3, "4th result is the 4th highest grid id");
+        assert_eq!(result[3].entries[0].grid_entry.id, 1, "4th result is the 4th highest grid id");
         assert_eq!(result[3].entries[0].grid_entry.relev, 0.96, "4th result grid has reduced relevance");
         assert_eq!(result[3].entries[0].matches_language, false, "4th result does not match language");
     }
@@ -606,19 +606,19 @@ fn coalesce_single_languages_test() {
     {
         assert_eq!(result.len(), 4, "Returns 4 results");
         assert_eq!(result[0].relev, 0.96, "1st result has reduced relevance");
-        assert_eq!(result[0].entries[0].grid_entry.id, 0, "1st result has lowest grid id, which is the tiebreaker for sorting");
+        assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st result has highest grid id, which is the tiebreaker for sorting");
         assert_eq!(result[0].entries[0].grid_entry.relev, 0.96, "1st result grid has reduced relevance");
         assert_eq!(result[0].entries[0].matches_language, false, "1st result does not match language");
         assert_eq!(result[1].relev, 0.96, "2nd result has reduced relevance");
-        assert_eq!(result[1].entries[0].grid_entry.id, 1, "2nd result is the 2nd highest grid id");
+        assert_eq!(result[1].entries[0].grid_entry.id, 2, "2nd result is the 2nd highest grid id");
         assert_eq!(result[1].entries[0].grid_entry.relev, 0.96, "2nd result grid has reduced relevance");
         assert_eq!(result[1].entries[0].matches_language, false, "2nd result does not match language");
         assert_eq!(result[2].relev, 0.96, "3rd result has reduced relevance");
-        assert_eq!(result[2].entries[0].grid_entry.id, 2, "3rd result is the 3rd highest grid id");
+        assert_eq!(result[2].entries[0].grid_entry.id, 1, "3rd result is the 3rd highest grid id");
         assert_eq!(result[2].entries[0].grid_entry.relev, 0.96, "3rd result grid has reduced relevance");
         assert_eq!(result[2].entries[0].matches_language, false, "3rd result does not match language");
         assert_eq!(result[3].relev, 0.96, "4th result has reduced relevance");
-        assert_eq!(result[3].entries[0].grid_entry.id, 3, "4th result is the 4th highest grid id");
+        assert_eq!(result[3].entries[0].grid_entry.id, 0, "4th result is the 4th highest grid id");
         assert_eq!(result[3].entries[0].grid_entry.relev, 0.96, "4th result grid has reduced relevance");
         assert_eq!(result[3].entries[0].matches_language, false, "4th result does not match language");
     }
@@ -925,7 +925,7 @@ fn coalesce_multi_languages_test() {
         assert_eq!(result.len(), 2, "Two results are returned");
         assert_eq!(result[0].entries.len(), 2, "1st context has two entries");
         assert_eq!(result[0].relev, 1., "1st context has relevance of 1");
-        assert_eq!(result[0].entries[0].grid_entry.id, 2, "1st entry in 1st result has lowest grid id, which is the tiebreaker for sorting");
+        assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st entry in 1st result has highest grid id, which is the tiebreaker for sorting");
         assert_eq!(result[0].entries[0].grid_entry.relev, 0.5, "1st entry in 1st result has original relevance" );
         assert_eq!(result[0].entries[0].matches_language, true, "1st entry in 1st result matches language" );
         assert_eq!(result[0].entries[1].grid_entry.id, 1, "2nd entry in 1st result is the overapping grid" );
@@ -933,7 +933,7 @@ fn coalesce_multi_languages_test() {
         assert_eq!(result[0].entries[1].matches_language, true, "2nd entry in 1st result matches language" );
         assert_eq!(result[1].entries.len(), 2, "2nd context has two entries");
         assert_eq!(result[1].relev, 1., "2nd context has relevance of 1");
-        assert_eq!(result[1].entries[0].grid_entry.id, 3, "1st entry in 2nd result is the higher grid id" );
+        assert_eq!(result[1].entries[0].grid_entry.id, 2, "1st entry in 2nd result is the lower grid id" );
         assert_eq!(result[1].entries[0].grid_entry.relev, 0.5, "1st entry in 2nd result has original relevance" );
         assert_eq!(result[1].entries[0].matches_language, true, "1st entry in 2nd result matches language" );
         assert_eq!(result[1].entries[1].grid_entry.id, 1, "2nd entry in 2nd result is the overlapping grid" );
@@ -1025,7 +1025,7 @@ fn coalesce_multi_languages_test() {
         assert_eq!(result.len(), 2, "Two results are returned");
         assert_eq!(result[0].entries.len(), 2, "1st context has two entries");
         assert_eq!(result[0].relev, 0.98, "1st context has lower overall relevance due to language penalty");
-        assert_eq!(result[0].entries[0].grid_entry.id, 2, "1st entry in 1st result has lowest grid id, which is the tiebreaker for sorting");
+        assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st entry in 1st result has highest grid id, which is the tiebreaker for sorting");
         assert_eq!(result[0].entries[0].grid_entry.relev, 0.48, "1st entry in 1st result has lower relevance due to language penalty");
         assert_eq!(result[0].entries[0].matches_language, false, "1st entry in 1st result does not match language");
         assert_eq!(result[0].entries[1].grid_entry.id, 1, "2nd entry in 1st result is the overapping grid");
@@ -1033,7 +1033,7 @@ fn coalesce_multi_languages_test() {
         assert_eq!(result[0].entries[1].matches_language, true, "2nd entry in 1st result matches language");
         assert_eq!(result[1].entries.len(), 2, "2nd context has two entries");
         assert_eq!(result[1].relev, 0.98, "2nd context has lower overall relevance due to language penalty");
-        assert_eq!(result[1].entries[0].grid_entry.id, 3, "1st entry in 2nd result has the id of the other grid");
+        assert_eq!(result[1].entries[0].grid_entry.id, 2, "1st entry in 2nd result has the id of the other grid");
         assert_eq!(result[1].entries[0].grid_entry.relev, 0.48, "1st entry in 2nd result has lower relevance due to language penalty");
         assert_eq!(result[1].entries[0].matches_language, false, "1st entry in 2nd result does not match language");
         assert_eq!(result[1].entries[1].grid_entry.id, 1, "2nd entry in 2nd result is the overlapping grid");

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,7 +439,7 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d3-queue@^3.0.2:
+d3-queue@^3.0.2, d3-queue@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.7.tgz#c93a2e54b417c0959129d7d73f6cf7d4292e7618"
 


### PR DESCRIPTION
This adds more tests for the variable-bins logic, to make sure the behavior is consistent with indexes without pre-combined bins. It also adds tests in JS, of which there weren't any before.

One other big change: it alters the sort order for output from coalesce, to be sorted by `(relev desc, scoredist desc, x desc, y desc, id desc)` so that it's the same as things are ordered in storage, instead of what it was before and is in carmen-cache, which is `(relev desc, scoredist desc, id asc, x asc, y asc)`. The ordering by x/y/id is arbitrary and just for consistency, and there's no reason any particular ordering is better than any other ordering, but the fact that different parts of the code used different sort orders was causing some slightly inconsistent behaviors between the version of the code with bins and the version without. This might make slight differences in api-geocoder in cases where there are ties, but we shouldn't see changes that are either consistently better or worse, just different.