### PR TITLE
Spatial tests

### DIFF
--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -184,256 +184,256 @@ fn coord_binary_search<'a>(
     }
 }
 
-// #[cfg(test)]
-// fn flatbuffer_generator<T: Iterator<Item = u32>>(val: T) -> Vec<u8> {
-//     let mut fb_builder = flatbuffers::FlatBufferBuilder::new_with_capacity(256);
-//     let mut coords: Vec<_> = Vec::new();
-//
-//     for i in val {
-//         let fb_coord = Coord::new(i as u32, 0);
-//         coords.push(fb_coord);
-//     }
-//     let fb_coords = fb_builder.create_vector(&coords);
-//
-//     let fb_rs = RelevScore::create(
-//         &mut fb_builder,
-//         &RelevScoreArgs { relev_score: 1, coords: Some(fb_coords) },
-//     );
-//     fb_builder.finish(fb_rs, None);
-//     let data = fb_builder.finished_data();
-//     Vec::from(data)
-// }
-//
-// #[cfg(test)]
-// mod test {
-//     use super::*;
-//
-//     #[test]
-//     fn filter_bbox() {
-//         let empty: Vec<u32> = vec![];
-//         let buffer = flatbuffer_generator(empty.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         assert_eq!(bbox_filter(coords, [0, 0, 0, 0]).is_none(), true);
-//
-//         let buffer = flatbuffer_generator((0..4).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 4);
-//
-//         let buffer = flatbuffer_generator((2..4).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 2, "starts before bbox and ends between the result set");
-//
-//         let buffer = flatbuffer_generator((2..4).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [1, 1, 3, 1]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 1, "starts in the bbox and ends after the result set");
-//
-//         let buffer = flatbuffer_generator((1..4).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [0, 1, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 2, "starts in the bbox and ends in the bbox");
-//
-//         let buffer = flatbuffer_generator((5..7).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         assert_eq!(
-//             bbox_filter(coords, [0, 0, 0, 1]).is_none(),
-//             true,
-//             "bbox ends before the range of coordinates"
-//         );
-//         assert_eq!(
-//             bbox_filter(coords, [4, 0, 4, 1]).is_none(),
-//             true,
-//             "bbox starts after the range of coordinates"
-//         );
-//
-//         let sparse: Vec<u32> = vec![24, 7];
-//         let buffer = flatbuffer_generator(sparse.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 2, "sparse result set that spans z-order jumps");
-//
-//         let buffer = flatbuffer_generator((7..24).rev());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 3, "continuous result set that spans z-order jumps");
-//
-//         let sparse: Vec<u32> = vec![8];
-//         let buffer = flatbuffer_generator(sparse.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
-//         assert_eq!(result.len(), 0, "result is on the z-order curve but not in the bbox");
-//     }
-//
-//     #[test]
-//     fn proximity_search() {
-//         let buffer = flatbuffer_generator((1..10).rev()); // [9,8,7,6,5,4,3,2,1]
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//
-//         let result = proximity(coords, [3, 0]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![5, 4, 6, 7, 3, 2, 8, 9, 1],
-//             result,
-//             "proximity point is in the middle of the result set - 5"
-//         );
-//
-//         let result = proximity(coords, [0, 3]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![9, 8, 7, 6, 5, 4, 3, 2, 1],
-//             result,
-//             "proximity point is greater than the result set - 10"
-//         );
-//
-//         let result = proximity(coords, [1, 0]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
-//             result,
-//             "proximity point is lesser than the result set - 1"
-//         );
-//
-//         let empty: Vec<u32> = vec![];
-//         let buffer = flatbuffer_generator(empty.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         assert_eq!(proximity(coords, [3, 0]).is_none(), true);
-//
-//         let sparse: Vec<u32> = vec![24, 21, 13, 8, 7, 6, 1]; // 1 and 13 are at the same distance from 7
-//         let buffer = flatbuffer_generator(sparse.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = proximity(coords, [3, 1]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![7, 6, 8, 13, 1, 21, 24],
-//             result,
-//             "sparse result set sorted by z-order in the middle of the result set"
-//         );
-//     }
-//
-//     #[test]
-//     fn bbox_proximity_search() {
-//         let buffer = flatbuffer_generator((1..10).rev()); // [9,8,7,6,5,4,3,2,1]
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         // bbox is from 1-7; proximity is 4
-//         let result = bbox_proximity_filter(coords, [1, 0, 3, 1], [2, 0])
-//             .unwrap()
-//             .map(|x| x.coord)
-//             .collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![4, 3, 5, 6, 7, 1],
-//             result,
-//             "bbox within the range of coordinates; proximity point within the result set"
-//         );
-//
-//         assert_eq!(
-//             bbox_proximity_filter(coords, [6, 4, 7, 5], [2, 0]).is_none(),
-//             true,
-//             "bbox outside list of coordinates; proximity within the result set"
-//         );
-//
-//         let result = bbox_proximity_filter(coords, [1, 0, 3, 1], [0, 0])
-//             .unwrap()
-//             .map(|x| x.coord)
-//             .collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![1, 3, 4, 5, 6, 7],
-//             result,
-//             "bbox within the range of coordinates; proximity point outside the result set"
-//         );
-//
-//         let buffer = flatbuffer_generator((2..5).rev()); // [4,3,2]
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         let result = bbox_proximity_filter(coords, [1, 1, 3, 1], [0, 0]) // bbox is 3-7; proximity is 0
-//             .unwrap()
-//             .map(|x| x.coord)
-//             .collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![3],
-//             result,
-//             "bbox starts in between the list of coordinates and ends after; proximity point outside the result set"
-//         );
-//
-//         let sparse: Vec<u32> = vec![24, 23, 13, 8, 7, 6, 1];
-//         let buffer = flatbuffer_generator(sparse.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         // bbox is 7-23; proximity is 7
-//         let result = bbox_proximity_filter(coords, [3, 1, 7, 1], [3, 1])
-//             .unwrap()
-//             .map(|x| x.coord)
-//             .collect::<Vec<u32>>();
-//         assert_eq!(
-//             vec![7, 23],
-//             result,
-//             "bbox within sparse result set; proximity within result set"
-//         );
-//     }
-//
-//     #[test]
-//     fn binary_search() {
-//         // Empty Coord list
-//         let empty: Vec<u32> = vec![];
-//         let buffer = flatbuffer_generator(empty.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//         assert_eq!(coord_binary_search(&coords, 0, 0), Err("Offset greater than Vector"));
-//         assert_eq!(coord_binary_search(&coords, 1, 0), Err("Offset greater than Vector"));
-//
-//         // Single Coord list
-//         let single: Vec<u32> = vec![0];
-//         let buffer = flatbuffer_generator(single.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//
-//         assert_eq!(coord_binary_search(&coords, 0, 0), Ok(0));
-//         assert_eq!(coord_binary_search(&coords, 1, 0), Ok(0));
-//
-//         // Continuous Coord list
-//         let buffer = flatbuffer_generator((4..8).rev()); // [7,6,5,4]
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//
-//         assert_eq!(coord_binary_search(&coords, 0, 0), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 4, 0), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 4, 1), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 5, 0), Ok(2));
-//         assert_eq!(coord_binary_search(&coords, 6, 0), Ok(1));
-//         assert_eq!(coord_binary_search(&coords, 7, 0), Ok(0));
-//         assert_eq!(coord_binary_search(&coords, 7, 3), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
-//         assert_eq!(coord_binary_search(&coords, 8, 0), Ok(0));
-//
-//         // Sparse Coord list
-//         let sparse: Vec<u32> = vec![7, 4, 2, 1];
-//         let buffer = flatbuffer_generator(sparse.into_iter());
-//         let rs = flatbuffers::get_root::<RelevScore>(&buffer);
-//         let coords = rs.coords().unwrap();
-//
-//         assert_eq!(coord_binary_search(&coords, 0, 0), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 1, 0), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 1, 1), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 2, 0), Ok(2));
-//         assert_eq!(coord_binary_search(&coords, 3, 0), Ok(2));
-//         assert_eq!(coord_binary_search(&coords, 4, 0), Ok(1));
-//         assert_eq!(coord_binary_search(&coords, 5, 0), Ok(1));
-//         assert_eq!(coord_binary_search(&coords, 7, 0), Ok(0));
-//         assert_eq!(coord_binary_search(&coords, 7, 3), Ok(3));
-//         assert_eq!(coord_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
-//         assert_eq!(coord_binary_search(&coords, 8, 0), Ok(0));
-//     }
-// }
+#[cfg(test)]
+fn flatbuffer_generator<T: Iterator<Item = u32>>(val: T) -> Vec<u8> {
+    let mut fb_builder = flatbuffers::FlatBufferBuilder::new_with_capacity(256);
+    let mut coords: Vec<_> = Vec::new();
+
+    for i in val {
+        let fb_coord = Coord::new(i as u32, 0);
+        coords.push(fb_coord);
+    }
+    let fb_coords = fb_builder.create_vector(&coords);
+
+    let fb_rs = RelevScore::create(
+        &mut fb_builder,
+        &RelevScoreArgs { relev_score: 1, coords: Some(fb_coords) },
+    );
+    fb_builder.finish(fb_rs, None);
+    let data = fb_builder.finished_data();
+    Vec::from(data)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn filter_bbox() {
+        let empty: Vec<u32> = vec![];
+        let buffer = flatbuffer_generator(empty.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        assert_eq!(bbox_filter(coords, [0, 0, 0, 0]).is_none(), true);
+
+        let buffer = flatbuffer_generator((0..4).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 4);
+
+        let buffer = flatbuffer_generator((2..4).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [0, 0, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 2, "starts before bbox and ends between the result set");
+
+        let buffer = flatbuffer_generator((2..4).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [1, 1, 3, 1]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 1, "starts in the bbox and ends after the result set");
+
+        let buffer = flatbuffer_generator((1..4).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [0, 1, 1, 1]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 2, "starts in the bbox and ends in the bbox");
+
+        let buffer = flatbuffer_generator((5..7).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        assert_eq!(
+            bbox_filter(coords, [0, 0, 0, 1]).is_none(),
+            true,
+            "bbox ends before the range of coordinates"
+        );
+        assert_eq!(
+            bbox_filter(coords, [4, 0, 4, 1]).is_none(),
+            true,
+            "bbox starts after the range of coordinates"
+        );
+
+        let sparse: Vec<u32> = vec![24, 7];
+        let buffer = flatbuffer_generator(sparse.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 2, "sparse result set that spans z-order jumps");
+
+        let buffer = flatbuffer_generator((7..24).rev());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 3, "continuous result set that spans z-order jumps");
+
+        let sparse: Vec<u32> = vec![8];
+        let buffer = flatbuffer_generator(sparse.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_filter(coords, [3, 1, 4, 2]).unwrap().cloned().collect::<Vec<Coord>>();
+        assert_eq!(result.len(), 0, "result is on the z-order curve but not in the bbox");
+    }
+
+    #[test]
+    fn proximity_search() {
+        let buffer = flatbuffer_generator((1..10).rev()); // [9,8,7,6,5,4,3,2,1]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+
+        let result = proximity(coords, [3, 0]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
+        assert_eq!(
+            vec![5, 4, 6, 7, 3, 2, 8, 9, 1],
+            result,
+            "proximity point is in the middle of the result set - 5"
+        );
+
+        let result = proximity(coords, [0, 3]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
+        assert_eq!(
+            vec![9, 8, 7, 6, 5, 4, 3, 2, 1],
+            result,
+            "proximity point is greater than the result set - 10"
+        );
+
+        let result = proximity(coords, [1, 0]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
+        assert_eq!(
+            vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+            result,
+            "proximity point is lesser than the result set - 1"
+        );
+
+        let empty: Vec<u32> = vec![];
+        let buffer = flatbuffer_generator(empty.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        assert_eq!(proximity(coords, [3, 0]).is_none(), true);
+
+        let sparse: Vec<u32> = vec![24, 21, 13, 8, 7, 6, 1]; // 1 and 13 are at the same distance from 7
+        let buffer = flatbuffer_generator(sparse.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = proximity(coords, [3, 1]).unwrap().map(|x| x.coord).collect::<Vec<u32>>();
+        assert_eq!(
+            vec![7, 6, 8, 13, 1, 21, 24],
+            result,
+            "sparse result set sorted by z-order in the middle of the result set"
+        );
+    }
+
+    #[test]
+    fn bbox_proximity_search() {
+        let buffer = flatbuffer_generator((1..10).rev()); // [9,8,7,6,5,4,3,2,1]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        // bbox is from 1-7; proximity is 4
+        let result = bbox_proximity_filter(coords, [1, 0, 3, 1], [2, 0])
+            .unwrap()
+            .map(|x| x.coord)
+            .collect::<Vec<u32>>();
+        assert_eq!(
+            vec![4, 3, 5, 6, 7, 1],
+            result,
+            "bbox within the range of coordinates; proximity point within the result set"
+        );
+
+        assert_eq!(
+            bbox_proximity_filter(coords, [6, 4, 7, 5], [2, 0]).is_none(),
+            true,
+            "bbox outside list of coordinates; proximity within the result set"
+        );
+
+        let result = bbox_proximity_filter(coords, [1, 0, 3, 1], [0, 0])
+            .unwrap()
+            .map(|x| x.coord)
+            .collect::<Vec<u32>>();
+        assert_eq!(
+            vec![1, 3, 4, 5, 6, 7],
+            result,
+            "bbox within the range of coordinates; proximity point outside the result set"
+        );
+
+        let buffer = flatbuffer_generator((2..5).rev()); // [4,3,2]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        let result = bbox_proximity_filter(coords, [1, 1, 3, 1], [0, 0]) // bbox is 3-7; proximity is 0
+            .unwrap()
+            .map(|x| x.coord)
+            .collect::<Vec<u32>>();
+        assert_eq!(
+            vec![3],
+            result,
+            "bbox starts in between the list of coordinates and ends after; proximity point outside the result set"
+        );
+
+        let sparse: Vec<u32> = vec![24, 23, 13, 8, 7, 6, 1];
+        let buffer = flatbuffer_generator(sparse.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        // bbox is 7-23; proximity is 7
+        let result = bbox_proximity_filter(coords, [3, 1, 7, 1], [3, 1])
+            .unwrap()
+            .map(|x| x.coord)
+            .collect::<Vec<u32>>();
+        assert_eq!(
+            vec![7, 23],
+            result,
+            "bbox within sparse result set; proximity within result set"
+        );
+    }
+
+    #[test]
+    fn binary_search() {
+        // Empty Coord list
+        let empty: Vec<u32> = vec![];
+        let buffer = flatbuffer_generator(empty.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+        assert_eq!(coord_binary_search(&coords, 0, 0), Err("Offset greater than Vector"));
+        assert_eq!(coord_binary_search(&coords, 1, 0), Err("Offset greater than Vector"));
+
+        // Single Coord list
+        let single: Vec<u32> = vec![0];
+        let buffer = flatbuffer_generator(single.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+
+        assert_eq!(coord_binary_search(&coords, 0, 0), Ok(0));
+        assert_eq!(coord_binary_search(&coords, 1, 0), Ok(0));
+
+        // Continuous Coord list
+        let buffer = flatbuffer_generator((4..8).rev()); // [7,6,5,4]
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+
+        assert_eq!(coord_binary_search(&coords, 0, 0), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 4, 0), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 4, 1), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 5, 0), Ok(2));
+        assert_eq!(coord_binary_search(&coords, 6, 0), Ok(1));
+        assert_eq!(coord_binary_search(&coords, 7, 0), Ok(0));
+        assert_eq!(coord_binary_search(&coords, 7, 3), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
+        assert_eq!(coord_binary_search(&coords, 8, 0), Ok(0));
+
+        // Sparse Coord list
+        let sparse: Vec<u32> = vec![7, 4, 2, 1];
+        let buffer = flatbuffer_generator(sparse.into_iter());
+        let rs = flatbuffers::get_root::<RelevScore>(&buffer);
+        let coords = rs.coords().unwrap();
+
+        assert_eq!(coord_binary_search(&coords, 0, 0), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 1, 0), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 1, 1), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 2, 0), Ok(2));
+        assert_eq!(coord_binary_search(&coords, 3, 0), Ok(2));
+        assert_eq!(coord_binary_search(&coords, 4, 0), Ok(1));
+        assert_eq!(coord_binary_search(&coords, 5, 0), Ok(1));
+        assert_eq!(coord_binary_search(&coords, 7, 0), Ok(0));
+        assert_eq!(coord_binary_search(&coords, 7, 3), Ok(3));
+        assert_eq!(coord_binary_search(&coords, 7, 4), Err("Offset greater than Vector"));
+        assert_eq!(coord_binary_search(&coords, 8, 0), Ok(0));
+    }
+}
 
 /// Calculates the tile distance between a proximity x and y and a grid x and y
 pub fn tile_dist(proximity_x: u16, proximity_y: u16, grid_x: u16, grid_y: u16) -> f64 {

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -4,9 +4,9 @@ use morton::{deinterleave_morton, interleave_morton};
 use std::cmp::Ordering::{Equal, Greater, Less};
 
 #[cfg(test)]
-use crate::gridstore::gridstore_format;
-#[cfg(test)]
 use crate::gridstore::common::relev_float_to_int;
+#[cfg(test)]
+use crate::gridstore::gridstore_format;
 
 /// Generate a tuple of the (min, max) range of the Coord Vector that overlaps with the bounding box
 ///
@@ -216,13 +216,12 @@ fn encoded_val_generator<T: Iterator<Item = u32>>(val: T) -> Vec<u8> {
 }
 
 #[cfg(test)]
-fn get_coords_from_reader<'a>(reader: &'a gridstore_format::Reader<&'a [u8]>) -> gridstore_format::UniformVec<'a, gridstore_format::Coord> {
+fn get_coords_from_reader<'a>(
+    reader: &'a gridstore_format::Reader<&'a [u8]>,
+) -> gridstore_format::UniformVec<'a, gridstore_format::Coord> {
     let record = gridstore_format::read_phrase_record_from(reader);
 
-    let rs_obj = reader.read_var_vec(record.relev_scores)
-        .into_iter()
-        .next()
-        .unwrap();
+    let rs_obj = reader.read_var_vec(record.relev_scores).into_iter().next().unwrap();
 
     reader.read_uniform_vec(rs_obj.coords)
 }


### PR DESCRIPTION
With the switch to a homegrown data format, I had commented out a bunch of tests in `spatial.rs` that depended on constructing a `flatbuffers` record and then operating on it with spatial functions. This PR uncomments all of that, and ports it to use the new format.

Obscured in the giant diff are a few functions that have actually had their results change since they were commented out. I'll point them out in comments, but in a nutshell, in some cases the sort order for spatial sorts will have slightly changed in instances where multiple possible results were tied. Bisecting suggests that this happened with [this commit](https://github.com/mapbox/carmen-core/commit/59350ea3c1eee635e55c5a0a251d2ec92df43f19) back in September, which ported some uses of `kmerge_by` in the spatial code to `merge_by` for efficiency reasons; merge_by seems to occasionally make different (arbitrary) decisions in the case of ties. Seems fine though.