### PR TITLE
Clean up common.rs todos

### DIFF
--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -230,9 +230,14 @@ fn adjust_to_zoom_test_proximity() {
 #[test]
 fn adjust_to_zoom_text_bbox() {
     // Test bottom right most tile at highest zoom
-    let match_opts = MatchOpts { bbox: Some([32760, 32758, 32767, 32714]), zoom: 15, ..MatchOpts::default() };
+    let match_opts =
+        MatchOpts { bbox: Some([32760, 32758, 32767, 32714]), zoom: 15, ..MatchOpts::default() };
     let zoomed_in_16 = match_opts.adjust_to_zoom(16);
-    assert_eq!(zoomed_in_16.bbox.unwrap(), [65520, 65516, 65535, 65429], "does not error while zooming into the right most tile on the highest zoom level");
+    assert_eq!(
+        zoomed_in_16.bbox.unwrap(),
+        [65520, 65516, 65535, 65429],
+        "does not error while zooming into the right most tile on the highest zoom level"
+    );
 
     // Test case where single parent tile contains entire bbox
     let match_opts = MatchOpts { bbox: Some([6, 4, 7, 5]), zoom: 4, ..MatchOpts::default() };

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,10 +1,9 @@
 use std::borrow::Borrow;
 
+use crate::gridstore::store::GridStore;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use failure::Error;
 use serde::{Deserialize, Serialize, Serializer};
-
-use crate::gridstore::store::GridStore;
 
 #[derive(Serialize, Deserialize, Debug, PartialOrd, Ord, PartialEq, Eq, Clone)]
 pub struct GridKey {
@@ -179,127 +178,156 @@ impl MatchOpts {
     }
 }
 
-#[test]
-fn adjust_to_zoom_test_proximity() {
-    let match_opts1 = MatchOpts {
-        proximity: Some(Proximity { point: [2, 28], radius: 400. }),
-        zoom: 14,
-        ..MatchOpts::default()
-    };
-    let adjusted_match_opts1 = match_opts1.adjust_to_zoom(6);
-    assert_eq!(adjusted_match_opts1.zoom, 6, "Adjusted MatchOpts should have target zoom as zoom");
-    assert_eq!(adjusted_match_opts1.proximity.unwrap().point, [0, 0], "should be 0,0");
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use once_cell::sync::Lazy;
 
-    let match_opts2 = MatchOpts {
-        proximity: Some(Proximity { point: [11, 25], radius: 400. }),
-        zoom: 6,
-        ..MatchOpts::default()
-    };
-    let adjusted_match_opts2 = match_opts2.adjust_to_zoom(8);
-    assert_eq!(adjusted_match_opts2.zoom, 8, "Adjusted MatchOpts should have target zoom as zoom");
-    assert_eq!(adjusted_match_opts2.proximity.unwrap().point, [45, 101], "Should be 45, 101");
+    fn matchopts_proximity_generator(point: [u16; 2], radius: f64, zoom: u16) -> MatchOpts {
+        MatchOpts {
+            proximity: Some(Proximity { point: point, radius: radius }),
+            zoom: zoom,
+            ..MatchOpts::default()
+        }
+    }
 
-    let match_opts3 = MatchOpts {
-        proximity: Some(Proximity { point: [6, 6], radius: 400. }),
-        zoom: 4,
-        ..MatchOpts::default()
-    };
+    #[test]
+    fn adjust_to_zoom_test_proximity() {
+        static MATCH_OPTS_PROXIMITY: Lazy<(MatchOpts, MatchOpts, MatchOpts)> = Lazy::new(|| {
+            let match_opts1 = matchopts_proximity_generator([2, 28], 400., 14);
+            let match_opts2 = matchopts_proximity_generator([11, 25], 400., 6);
+            let match_opts3 = matchopts_proximity_generator([6, 6], 400., 4);
+            (match_opts1, match_opts2, match_opts3)
+        });
 
-    let same_zoom = match_opts3.adjust_to_zoom(4);
-    assert_eq!(same_zoom, match_opts3, "If the zoom is the same as the original, adjusted MatchOpts should be a clone of the original");
-    let zoomed_out_1z = match_opts3.adjust_to_zoom(3);
-    let proximity_out_1z = zoomed_out_1z.proximity.unwrap();
-    assert_eq!(proximity_out_1z.point, [3, 3], "4/6/6 zoomed out to zoom 3 should be 3/3/3");
-    assert_eq!(proximity_out_1z.radius, 400., "The adjusted radius should be the original radius");
-    assert_eq!(zoomed_out_1z.zoom, 3, "The adjusted zoom should be the target zoom");
-    let zoomed_out_2z = match_opts3.adjust_to_zoom(2);
-    let proximity_out_2z = zoomed_out_2z.proximity.unwrap();
-    assert_eq!(proximity_out_2z.point, [1, 1], "4/6/6 zoomed out to zoom 2 should be 2/1/1");
-    let zoomed_in_1z = match_opts3.adjust_to_zoom(5);
-    let proximity_in_1z = zoomed_in_1z.proximity.unwrap();
-    assert_eq!(proximity_in_1z.point, [12, 12], "4/6/6 zoomed in to zoom 5 should be 5/12/12");
-    assert_eq!(zoomed_in_1z.zoom, 5, "The adjusted zoom should be the target zoom");
-    let zoomed_in_2z = match_opts3.adjust_to_zoom(6);
-    let proximity_in_2z = zoomed_in_2z.proximity.unwrap();
-    assert_eq!(proximity_in_2z.point, [25, 25], "4/6/6 zoomed in to zoom 6 should be 6/25/25");
-    let zoomed_in_3z = match_opts3.adjust_to_zoom(7);
-    let proximity_in_3z = zoomed_in_3z.proximity.unwrap();
-    assert_eq!(proximity_in_3z.point, [51, 51], "4/6/6 zoomed in to zoom 7 should be 7/51/51");
-}
+        let adjusted_match_opts1 = MATCH_OPTS_PROXIMITY.0.adjust_to_zoom(6);
+        assert_eq!(
+            adjusted_match_opts1.zoom, 6,
+            "Adjusted MatchOpts should have target zoom as zoom"
+        );
+        assert_eq!(adjusted_match_opts1.proximity.unwrap().point, [0, 0], "should be 0,0");
 
-#[test]
-fn adjust_to_zoom_text_bbox() {
-    // Test bottom right most tile at highest zoom
-    let match_opts =
-        MatchOpts { bbox: Some([32760, 32758, 32767, 32714]), zoom: 15, ..MatchOpts::default() };
-    let zoomed_in_16 = match_opts.adjust_to_zoom(16);
-    assert_eq!(
-        zoomed_in_16.bbox.unwrap(),
-        [65520, 65516, 65535, 65429],
-        "does not error while zooming into the right most tile on the highest zoom level"
-    );
+        let adjusted_match_opts2 = MATCH_OPTS_PROXIMITY.1.adjust_to_zoom(8);
+        assert_eq!(
+            adjusted_match_opts2.zoom, 8,
+            "Adjusted MatchOpts should have target zoom as zoom"
+        );
+        assert_eq!(adjusted_match_opts2.proximity.unwrap().point, [45, 101], "Should be 45, 101");
 
-    // Test case where single parent tile contains entire bbox
-    let match_opts = MatchOpts { bbox: Some([6, 4, 7, 5]), zoom: 4, ..MatchOpts::default() };
-    let zoomed_out_1z = match_opts.adjust_to_zoom(3);
-    assert_eq!(zoomed_out_1z.bbox.unwrap(), [3,2,3,2], "Bbox covering 4 tiles zoomed out 1z can be 1 parent tile if it contains all 4 original tiles");
-    assert_eq!(zoomed_out_1z.zoom, 3, "The adjusted zoom should be the target zoom");
-    let zoomed_back_in_1z = zoomed_out_1z.adjust_to_zoom(4);
-    assert_eq!(
-        zoomed_back_in_1z, match_opts,
-        "The zoomed in bbox from 1 parent tile should include the 4 tiles it contains"
-    );
+        let same_zoom = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(4);
+        assert_eq!(same_zoom, MATCH_OPTS_PROXIMITY.2, "If the zoom is the same as the original, adjusted MatchOpts should be a clone of the original");
+        let zoomed_out_1z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(3);
+        let proximity_out_1z = zoomed_out_1z.proximity.unwrap();
+        assert_eq!(proximity_out_1z.point, [3, 3], "4/6/6 zoomed out to zoom 3 should be 3/3/3");
+        assert_eq!(
+            proximity_out_1z.radius, 400.,
+            "The adjusted radius should be the original radius"
+        );
+        assert_eq!(zoomed_out_1z.zoom, 3, "The adjusted zoom should be the target zoom");
 
-    // Test case where higher zoom level bbox spans multiple parent tiles
-    let match_opts2 = MatchOpts { bbox: Some([6, 5, 7, 6]), zoom: 4, ..MatchOpts::default() };
-    let zoomed_out_1z_2 = match_opts2.adjust_to_zoom(3);
-    assert_eq!(
-        zoomed_out_1z_2.bbox.unwrap(),
-        [3, 2, 3, 3],
-        "Bboxes that span two parent tiles should return a bbox that includes both parent tiles"
-    );
-    let zoomed_back_in_1z_2 = zoomed_out_1z_2.adjust_to_zoom(4);
-    assert_eq!(
-        zoomed_back_in_1z_2.bbox.unwrap(),
-        [6, 4, 7, 7],
-        "The zoomed in bbox from 2 parent tiles should include all 8 tiles they contain"
-    );
+        let zoomed_out_2z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(2);
+        let proximity_out_2z = zoomed_out_2z.proximity.unwrap();
+        assert_eq!(proximity_out_2z.point, [1, 1], "4/6/6 zoomed out to zoom 2 should be 2/1/1");
 
-    // Gut check simple case
-    let simple_match_opts = MatchOpts { bbox: Some([3, 3, 3, 3]), zoom: 3, ..MatchOpts::default() };
-    assert_eq!(
-        simple_match_opts.adjust_to_zoom(4).bbox.unwrap(),
-        [6, 6, 7, 7],
-        "[3,3,3,3] is correctly scaled to zoom 4"
-    );
-    assert_eq!(
-        simple_match_opts.adjust_to_zoom(5).bbox.unwrap(),
-        [12, 12, 15, 15],
-        "[3,3,3,3] is correctly scaled to zoom 5"
-    );
+        let zoomed_in_1z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(5);
+        let proximity_in_1z = zoomed_in_1z.proximity.unwrap();
+        assert_eq!(proximity_in_1z.point, [12, 12], "4/6/6 zoomed in to zoom 5 should be 5/12/12");
+        assert_eq!(zoomed_in_1z.zoom, 5, "The adjusted zoom should be the target zoom");
 
-    // Multi-tile parent bbox zoom in
-    let multi_tile_match_opts =
-        MatchOpts { bbox: Some([5, 3, 7, 4]), zoom: 3, ..MatchOpts::default() };
-    assert_eq!(
-        multi_tile_match_opts.adjust_to_zoom(4).bbox.unwrap(),
-        [10, 6, 15, 9],
-        "Multi-tile parent zoomed in one zoom level includes all the higher-zoom tiles"
-    );
-    assert_eq!(
-        multi_tile_match_opts.adjust_to_zoom(5).bbox.unwrap(),
-        [20, 12, 31, 19],
-        "Multi-tile parent zoomed in two zoom levels includes all the higher-zoom tiles"
-    );
+        let zoomed_in_2z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(6);
+        let proximity_in_2z = zoomed_in_2z.proximity.unwrap();
+        assert_eq!(proximity_in_2z.point, [25, 25], "4/6/6 zoomed in to zoom 6 should be 6/25/25");
 
-    // Multi-parent, multi-tile bbox zoomed out
-    let multi_parent_match_opts =
-        MatchOpts { bbox: Some([6, 3, 8, 4]), zoom: 5, ..MatchOpts::default() };
-    assert_eq!(
-        multi_parent_match_opts.adjust_to_zoom(4).bbox.unwrap(),
-        [3, 1, 4, 2],
-        "Multi-tile parent zoomed in one zoom level includes all the higher-zoom tiles"
-    );
+        let zoomed_in_3z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(7);
+        let proximity_in_3z = zoomed_in_3z.proximity.unwrap();
+        assert_eq!(proximity_in_3z.point, [51, 51], "4/6/6 zoomed in to zoom 7 should be 7/51/51");
+    }
+
+    fn matchopts_bbox_generator(bbox: [u16; 4], zoom: u16) -> MatchOpts {
+        MatchOpts { bbox: Some(bbox), zoom: zoom, ..MatchOpts::default() }
+    }
+
+    #[test]
+    fn adjust_to_zoom_text_bbox() {
+        static MATCH_OPTS_BBOX: Lazy<(
+            MatchOpts,
+            MatchOpts,
+            MatchOpts,
+            MatchOpts,
+            MatchOpts,
+            MatchOpts,
+        )> = Lazy::new(|| {
+            let match_opts1 = matchopts_bbox_generator([32760, 32758, 32767, 32714], 15);
+            let match_opts2 = matchopts_bbox_generator([6, 4, 7, 5], 4);
+            let match_opts3 = matchopts_bbox_generator([6, 5, 7, 6], 4);
+            let match_opts4 = matchopts_bbox_generator([3, 3, 3, 3], 3);
+            let match_opts5 = matchopts_bbox_generator([5, 3, 7, 4], 3);
+            let match_opts6 = matchopts_bbox_generator([6, 3, 8, 4], 5);
+            (match_opts1, match_opts2, match_opts3, match_opts4, match_opts5, match_opts6)
+        });
+        // Test bottom right most tile at highest zoom
+        let zoomed_in_16 = MATCH_OPTS_BBOX.0.adjust_to_zoom(16);
+        assert_eq!(
+            zoomed_in_16.bbox.unwrap(),
+            [65520, 65516, 65535, 65429],
+            "does not error while zooming into the right most tile on the highest zoom level"
+        );
+
+        // Test case where single parent tile contains entire bbox
+        let zoomed_out_1z = MATCH_OPTS_BBOX.1.adjust_to_zoom(3);
+        assert_eq!(zoomed_out_1z.bbox.unwrap(), [3,2,3,2], "Bbox covering 4 tiles zoomed out 1z can be 1 parent tile if it contains all 4 original tiles");
+        assert_eq!(zoomed_out_1z.zoom, 3, "The adjusted zoom should be the target zoom");
+        let zoomed_back_in_1z = zoomed_out_1z.adjust_to_zoom(4);
+        assert_eq!(
+            zoomed_back_in_1z, MATCH_OPTS_BBOX.1,
+            "The zoomed in bbox from 1 parent tile should include the 4 tiles it contains"
+        );
+
+        // Test case where higher zoom level bbox spans multiple parent tiles
+        let zoomed_out_1z_2 = MATCH_OPTS_BBOX.2.adjust_to_zoom(3);
+        assert_eq!(
+            zoomed_out_1z_2.bbox.unwrap(),
+            [3, 2, 3, 3],
+            "Bboxes that span two parent tiles should return a bbox that includes both parent tiles"
+        );
+        let zoomed_back_in_1z_2 = zoomed_out_1z_2.adjust_to_zoom(4);
+        assert_eq!(
+            zoomed_back_in_1z_2.bbox.unwrap(),
+            [6, 4, 7, 7],
+            "The zoomed in bbox from 2 parent tiles should include all 8 tiles they contain"
+        );
+
+        // Gut check simple case
+        assert_eq!(
+            MATCH_OPTS_BBOX.3.adjust_to_zoom(4).bbox.unwrap(),
+            [6, 6, 7, 7],
+            "[3,3,3,3] is correctly scaled to zoom 4"
+        );
+        assert_eq!(
+            MATCH_OPTS_BBOX.3.adjust_to_zoom(5).bbox.unwrap(),
+            [12, 12, 15, 15],
+            "[3,3,3,3] is correctly scaled to zoom 5"
+        );
+
+        // Multi-tile parent bbox zoom in
+        assert_eq!(
+            MATCH_OPTS_BBOX.4.adjust_to_zoom(4).bbox.unwrap(),
+            [10, 6, 15, 9],
+            "Multi-tile parent zoomed in one zoom level includes all the higher-zoom tiles"
+        );
+        assert_eq!(
+            MATCH_OPTS_BBOX.4.adjust_to_zoom(5).bbox.unwrap(),
+            [20, 12, 31, 19],
+            "Multi-tile parent zoomed in two zoom levels includes all the higher-zoom tiles"
+        );
+
+        // Multi-parent, multi-tile bbox zoomed out
+        assert_eq!(
+            MATCH_OPTS_BBOX.5.adjust_to_zoom(4).bbox.unwrap(),
+            [3, 1, 4, 2],
+            "Multi-tile parent zoomed in one zoom level includes all the higher-zoom tiles"
+        );
+    }
 }
 
 // keys consist of a marker byte indicating type (regular entry, prefix cache, etc.) followed by


### PR DESCRIPTION
### Context 
As a part of cleaning up todos in `common.rs` in carmen-core, I: 
- Added a test for a bounding box that covers the right most tile and zooms in from 15 -> 16. The original intent for adding the test as @Nmargolis wrote it was to check for any integer overflow errors while zooming in.
- Removed repetitive tests that checked for the proximity radius every time
- Added an explanation for why add a parenthesis for the zoom in calculation

cc @Nmargolis @CyanRook @apendleton 