### PR TITLE
clean up

### DIFF
--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -408,11 +408,9 @@ pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
 }
 
 #[derive(Serialize, Debug, Clone)]
-pub struct PhrasematchResults<'a, T: Borrow<GridStore> + Clone> {
+pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     #[serde(serialize_with = "serialize_path")]
     pub store: T,
-    pub subquery: Vec<&'a str>,
-    pub phrase: &'a str,
     pub scorefactor: u16,
     pub prefix: u8,
     pub weight: f64,
@@ -423,13 +421,7 @@ pub struct PhrasematchResults<'a, T: Borrow<GridStore> + Clone> {
     pub mask: u32,
     pub bmask: Vec<u32>,
     pub edit_multiplier: f64,
-    pub prox_match: bool,
-    pub cat_match: bool,
-    pub partial_number: bool,
     pub subquery_edit_distance: u8,
-    pub original_phrase: Vec<&'a str>,
-    pub original_phrase_ender: u8,
-    pub original_phrase_mask: u32
 }
 
 #[inline]

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -1,14 +1,15 @@
 mod builder;
 mod coalesce;
-mod stackable;
 mod common;
 mod gridstore_format;
 mod spatial;
+mod stackable;
 mod store;
 
 pub use builder::*;
 pub use coalesce::coalesce;
 pub use common::*;
+pub use stackable::stackable;
 pub use store::*;
 
 #[cfg(test)]

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -1,23 +1,28 @@
 #![allow(dead_code)]
-use std::fmt::Debug;
 use std::borrow::Borrow;
+use std::fmt::Debug;
 
-use crate::gridstore::store::*;
 use crate::gridstore::builder::*;
-use crate::gridstore::common::*;
 use crate::gridstore::common::MatchPhrase::Range;
+use crate::gridstore::common::*;
+use crate::gridstore::store::*;
 
 #[derive(Debug, Clone)]
-pub struct StackableNode<'a, T: Borrow<GridStore> + Clone + Debug> {
-    pub phrasematch: Option<PhrasematchResults<'a, T>>,
-    pub children: Vec<StackableNode<'a, T>>,
+pub struct StackableNode<T: Borrow<GridStore> + Clone + Debug> {
+    pub phrasematch: Option<PhrasematchResults<T>>,
+    pub children: Vec<StackableNode<T>>,
     pub nmask: u32,
     pub bmask: Vec<u32>,
-    pub mask: u32
+    pub mask: u32,
 }
 
-pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(phrasematch_results: &Vec<Vec<PhrasematchResults<'a, T>>>, phrasematch_result: Option<PhrasematchResults<'a, T>>, nmask: u32, bmask: Vec<u32>, mask: u32) -> StackableNode<'a, T> {
-    let mut children: Vec<StackableNode<'a, T>> = vec![];
+pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
+    phrasematch_results: &Vec<Vec<PhrasematchResults<T>>>,
+    phrasematch_result: Option<PhrasematchResults<T>>,
+    nmask: u32,
+    bmask: Vec<u32>,
+    mask: u32,
+) -> StackableNode<T> {
     let mut node = StackableNode {
         phrasematch: phrasematch_result,
         children: vec![],
@@ -28,10 +33,16 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(phrasematch_results: 
 
     for phrasematch_per_index in phrasematch_results.iter() {
         for phrasematches in phrasematch_per_index.iter() {
-            if (node.nmask & phrasematches.nmask) == 0  && (node.mask & phrasematches.mask) == 0 {
-            let target_nmask = &phrasematches.nmask | node.nmask;
-            let target_mask = &phrasematches.idx | node.mask;
-            node.children.push(stackable(&phrasematch_results, Some(phrasematches.clone()), target_nmask, phrasematches.clone().bmask, target_mask));
+            if (node.nmask & phrasematches.nmask) == 0 && (node.mask & phrasematches.mask) == 0 {
+                let target_nmask = &phrasematches.nmask | node.nmask;
+                let target_mask = &phrasematches.idx | node.mask;
+                node.children.push(stackable(
+                    &phrasematch_results,
+                    Some(phrasematches.clone()),
+                    target_nmask,
+                    phrasematches.clone().bmask,
+                    target_mask,
+                ));
             }
         }
     }
@@ -43,67 +54,51 @@ mod test {
     use super::*;
     #[test]
     fn stackable_test() {
-    let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
-    let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
+        let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
+        let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
 
-    let key = GridKey { phrase_id: 1, lang_set: 1 };
+        let key = GridKey { phrase_id: 1, lang_set: 1 };
 
-    let entries = vec![
-        GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
-        GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 1 },
-        GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
-    ];
-    builder.insert(&key, entries).expect("Unable to insert record");
-    builder.finish().unwrap();
-    let store = GridStore::new(directory.path()).unwrap();
+        let entries = vec![
+            GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
+            GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 1 },
+            GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
+        ];
+        builder.insert(&key, entries).expect("Unable to insert record");
+        builder.finish().unwrap();
+        let store = GridStore::new(directory.path()).unwrap();
 
-    let phrasematch_1 = PhrasematchResults {
-        store: &store,
-        subquery: vec!["main", "street"],
-        phrase: "main street",
-        scorefactor: 1,
-        prefix: 0,
-        weight: 1.0,
-        match_key: MatchKey { match_phrase: Range { start: 0, end: 3 }, lang_set: 1 },
-        idx: 14,
-        zoom: 6,
-        nmask: 4,
-        mask: 1,
-        bmask: vec![0],
-        edit_multiplier: 1.0,
-        prox_match: false,
-        cat_match: false,
-        partial_number: false,
-        subquery_edit_distance: 0,
-        original_phrase: vec!["main", "street"],
-        original_phrase_ender: 0,
-        original_phrase_mask: 14
-    };
+        let phrasematch_1 = PhrasematchResults {
+            store: &store,
+            scorefactor: 1,
+            prefix: 0,
+            weight: 1.0,
+            match_key: MatchKey { match_phrase: Range { start: 0, end: 3 }, lang_set: 1 },
+            idx: 14,
+            zoom: 6,
+            nmask: 4,
+            mask: 1,
+            bmask: vec![0],
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
+        };
 
-    let phrasematch_2 = PhrasematchResults {
-        store: &store,
-        subquery: vec!["nw", "street"],
-        phrase: "nw street",
-        scorefactor: 1,
-        prefix: 0,
-        weight: 1.0,
-        match_key: MatchKey { match_phrase: Range { start: 0, end: 3 }, lang_set: 1 },
-        idx: 14,
-        zoom: 6,
-        nmask: 6,
-        mask: 1,
-        bmask: vec![0],
-        edit_multiplier: 1.0,
-        prox_match: false,
-        cat_match: false,
-        partial_number: false,
-        subquery_edit_distance: 0,
-        original_phrase: vec!["nw", "street"],
-        original_phrase_ender: 0,
-        original_phrase_mask: 14
-    };
+        let phrasematch_2 = PhrasematchResults {
+            store: &store,
+            scorefactor: 1,
+            prefix: 0,
+            weight: 1.0,
+            match_key: MatchKey { match_phrase: Range { start: 0, end: 3 }, lang_set: 1 },
+            idx: 14,
+            zoom: 6,
+            nmask: 6,
+            mask: 1,
+            bmask: vec![0],
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
+        };
 
-    let phrasematch_results = vec![vec![phrasematch_1, phrasematch_2]];
-    stackable(&phrasematch_results, None, 0, vec![0], 0);
+        let phrasematch_results = vec![vec![phrasematch_1, phrasematch_2]];
+        stackable(&phrasematch_results, None, 0, vec![0], 0);
     }
 }

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -470,28 +470,28 @@ tape('Deserialize phrasematch results', (t) => {
     let phrasematchResults = [
         {
             'phrasematches': [
-                new Phrasematch(store, ['main', 'street'], 'main street', 1, 14, [0, 2], 1, 0, 14, 4, 1, [0], 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0])
-            ]
+                new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0])
+            ],
+            idx: 0,
+            nmask: 14,
+            bmask: [0]
         }
     ];
-    addon.stack_to_trees(phrasematchResults);
+    addon.stackable(phrasematchResults);
     t.end();
 });
 
 
 
-function Phrasematch(store, subquery, phrase, weight, mask, phrase_id_range, scorefactor, prefix, idx, nmask, mask, bmask, zoom, edit_multiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages) {
+function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, edit_multiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages) {
     this.store = store;
     this.subquery = subquery;
     this.phrase = phrase;
     this.weight = weight;
-    this.nmask = nmask;
     this.mask = mask;
-    this.bmask = bmask;
     this.phrase_id_range = phrase_id_range;
     this.scorefactor = scorefactor;
     this.prefix = prefix;
-    this.idx = idx;
     this.zoom = zoom;
     this.edit_multiplier = edit_multiplier || 1;
     this.prox_match = prox_match || false;
@@ -521,7 +521,7 @@ function Phrasematch(store, subquery, phrase, weight, mask, phrase_id_range, sco
 }
 
 Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.subquery.slice(), this.weight, this.mask, this.phrase, this.phrase_id_range, this.scorefactor, this.idx, this.store, this.zoom, this.radius, this.prefix, this.languages, this.editMultiplier, this.proxMatch, this.catMatch, this.partialNumber, this.extendedScan, this.address);
+    return new Phrasematch(this.store, this.subquery.slice(), this.phrase, this.weight, this.phrase_id_range, this.scorefactor, this.prefix, this.mask, this.zoom, this.edit_multiplier, this.prox_match, this.cat_match, this.partial_number, this.subquery_edit_distance, this.original_phrase, this.original_phrase_ender, this.original_phrase_mask, this.languages);
 };
 
 module.exports.Phrasematch = Phrasematch;


### PR DESCRIPTION
Per next actions here: #64 
1. This PR cleans up the `PhrasematchResults` struct, removing parameters that we won't be using at all 
2. Cleans up a few of the variable names in functions (there could be more there)
3. Cleans up the test for making sure deserialize_js_phrasematchresults and js_stackable work as expected
4. Changes where nmask, idx and bmask get deserialised (since it happens for phrasematch results per index)

cc @CyanRook 