### PR TITLE
Use bmask for evaluation and calculate max relevance for root node

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -446,7 +446,7 @@ pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let js_phrasematch_result = { cx.argument::<JsArray>(0)? };
     let phrasematch_results: Vec<Vec<PhrasematchResults<ArcGridStore>>> =
         deserialize_phrasematch_results(&mut cx, js_phrasematch_result)?;
-    stackable(&phrasematch_results, None, 0, vec![], 0, 129, 0.0, 0.0);
+    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0.0);
 
     Ok(cx.undefined())
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -8,6 +8,7 @@ use carmen_core::gridstore::{
 use neon::prelude::*;
 use neon::{class_definition, declare_types, impl_managed, register_module};
 use neon_serde::errors::Result as LibResult;
+use std::collections::HashSet;
 use owning_ref::OwningHandle;
 use failure::Error;
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -447,7 +447,7 @@ pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let js_phrasematch_result = { cx.argument::<JsArray>(0)? };
     let phrasematch_results: Vec<Vec<PhrasematchResults<ArcGridStore>>> =
         deserialize_phrasematch_results(&mut cx, js_phrasematch_result)?;
-    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0.0);
+    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
 
     Ok(cx.undefined())
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -444,9 +444,9 @@ where
 
 pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let js_phrasematch_result = { cx.argument::<JsArray>(0)? };
-    let phrasematches_results: Vec<Vec<PhrasematchResults<ArcGridStore>>> =
+    let phrasematch_results: Vec<Vec<PhrasematchResults<ArcGridStore>>> =
         deserialize_phrasematch_results(&mut cx, js_phrasematch_result)?;
-    stackable(&phrasematches_results, None, 0, vec![0], 0);
+    stackable(&phrasematch_results, None, 0, vec![], 0, 129, 0.0, 0.0);
 
     Ok(cx.undefined())
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::collections::HashSet;
 
 use crate::gridstore::store::GridStore;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -419,7 +420,7 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub zoom: u16,
     pub nmask: u32,
     pub mask: u32,
-    pub bmask: Vec<u32>,
+    pub bmask: HashSet<u32>,
     pub edit_multiplier: f64,
     pub subquery_edit_distance: u8,
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -424,6 +424,14 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub subquery_edit_distance: u8,
 }
 
+/*
+impl PartialOrd for PhrasematchResults {
+    fn partial_cmp(&self, other: &PhrasematchResults) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+*/
+
 #[inline]
 pub fn relev_float_to_int(relev: f64) -> u8 {
     if relev == 0.4 {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -424,14 +424,6 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub subquery_edit_distance: u8,
 }
 
-/*
-impl PartialOrd for PhrasematchResults {
-    fn partial_cmp(&self, other: &PhrasematchResults) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-*/
-
 #[inline]
 pub fn relev_float_to_int(relev: f64) -> u8 {
     if relev == 0.4 {

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -49,10 +49,11 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
     for phrasematch_per_index in phrasematch_results.iter() {
         for phrasematches in phrasematch_per_index.iter() {
             if node.zoom > phrasematches.zoom {
-                if phrasematches.idx >= node.idx {
+                continue;
+            } else if node.zoom == phrasematches.zoom {
+                if node.idx < phrasematches.idx {
                     continue;
                 }
-                continue;
             }
 
             if (node.nmask & phrasematches.nmask) == 0

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -77,7 +77,7 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
                     phrasematches.idx,
                     target_relev,
                     target_adjusted_relev,
-                    phrasematches.zoom
+                    phrasematches.zoom,
                 ));
             }
         }


### PR DESCRIPTION
Per next action #64 - 

> Add bmask in the evaluation of whether stacks can align


Additionally, we also need the max relevance which is the sum of the node's relevance and the maximum of the children's relevances added to the parent node in order to be able to make intelligent decisions while traversing the tree. This PR calculates and adds the max_relevance property to the parent node and uses the bmask to evaluate whether stacks can align.

We also need a way to prevent duplicate branches by allowing stacking only in one direction otherwise, we could end up with a tree that has phrasematch results stacked as country -> postcode as well as postcode -> country. This PR also adds a condition to allow stacking to only happen only in one direction to prevent duplicate branches.