### PR TITLE
Stack and coalesce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1",
+  "version": "0.1.1-stack-and-coalesce-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -10,6 +10,7 @@ use ordered_float::OrderedFloat;
 
 use crate::gridstore::common::*;
 use crate::gridstore::store::GridStore;
+use crate::gridstore::stackable::StackableNode;
 
 /// Takes a vector of phrasematch subqueries (stack) and match options, gets matching grids, sorts the grids,
 /// and returns a result of a sorted vector of contexts (lists of grids with added metadata)
@@ -47,6 +48,28 @@ pub fn coalesce<T: Borrow<GridStore> + Clone + Debug>(
 fn grid_to_coalesce_entry<T: Borrow<GridStore> + Clone>(
     grid: &MatchEntry,
     subquery: &PhrasematchSubquery<T>,
+    match_opts: &MatchOpts,
+) -> CoalesceEntry {
+    // Zoom has been adjusted in coalesce_multi, or correct zoom has been passed in for coalesce_single
+    debug_assert!(match_opts.zoom == subquery.zoom);
+    let relevance = grid.grid_entry.relev * subquery.weight;
+
+    CoalesceEntry {
+        grid_entry: GridEntry { relev: relevance, ..grid.grid_entry },
+        matches_language: grid.matches_language,
+        idx: subquery.idx,
+        tmp_id: ((subquery.idx as u32) << 25) + grid.grid_entry.id,
+        mask: subquery.mask,
+        distance: grid.distance,
+        scoredist: grid.scoredist,
+    }
+}
+
+// this is the same as the above but temporarily necessitated by the PhrasematchSubquery vs.
+// PhrasematchResults split -- ick. we need to clean this up asap.
+fn grid_to_coalesce_entry_alt<T: Borrow<GridStore> + Clone>(
+    grid: &MatchEntry,
+    subquery: &PhrasematchResults<T>,
     match_opts: &MatchOpts,
 ) -> CoalesceEntry {
     // Zoom has been adjusted in coalesce_multi, or correct zoom has been passed in for coalesce_single
@@ -324,4 +347,238 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
     });
 
     Ok(contexts)
+}
+
+
+type TreeCoalesceState = HashMap<(u16, u16), Vec<CoalesceContext>>;
+
+pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
+    stack_tree: &StackableNode<T>,
+    match_opts: &MatchOpts,
+) -> Result<Vec<CoalesceContext>, Error> {
+    // the "tree" is just a node with no phrasematch; assure that this is the case
+    debug_assert!(stack_tree.phrasematch.is_none(), "no phrasematch on root node");
+
+    let mut contexts: Vec<CoalesceContext> = Vec::new();
+
+    for node in &stack_tree.children {
+        let subquery = node.phrasematch.as_ref().expect("phrasematch must be set on non-root tree nodes");
+
+        let mut zoom_adjusted_match_options = match_opts.clone();
+        if zoom_adjusted_match_options.zoom != subquery.zoom {
+            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.zoom);
+        }
+
+        if node.children.len() == 0 {
+            // we're not stacking this on top of anything, and we're not stacking anything else
+            // on top of this, so we can grab a minimal set of elements here
+            let bigger_max = 2 * MAX_CONTEXTS;
+
+            let grids = subquery.store.borrow().streaming_get_matching(
+                &subquery.match_key,
+                &zoom_adjusted_match_options,
+                // double to give us some sorting wiggle room
+                bigger_max,
+            )?;
+
+            let coalesced = tree_coalesce_single(
+                subquery,
+                match_opts,
+                grids
+            )?;
+
+            contexts.extend(coalesced);
+        } else {
+            // we need lots of grids because we don't know where the things we're stacking on top
+            // will be
+            let mut prev_state: TreeCoalesceState = TreeCoalesceState::new();
+            let grids = subquery.store.borrow().streaming_get_matching(
+                &subquery.match_key,
+                &zoom_adjusted_match_options,
+                MAX_GRIDS_PER_PHRASE,
+            )?;
+
+            for grid in grids.take(MAX_GRIDS_PER_PHRASE) {
+                let entry = grid_to_coalesce_entry_alt(&grid, subquery, match_opts);
+                let context = CoalesceContext {
+                    mask: subquery.mask,
+                    relev: entry.grid_entry.relev,
+                    entries: vec![entry],
+                };
+
+                contexts.push(context.clone());
+
+                let state_vec = prev_state.entry((grid.grid_entry.x, grid.grid_entry.y))
+                    .or_insert_with(|| vec![]);
+                state_vec.push(context);
+            }
+            tree_recurse(&node, match_opts, &prev_state, subquery.zoom, &mut contexts)?;
+        }
+    }
+
+    contexts.sort_by_key(|context| {
+        (
+            Reverse(OrderedFloat(context.relev)),
+            Reverse(OrderedFloat(context.entries[0].scoredist)),
+            context.entries[0].idx,
+            Reverse(context.entries[0].grid_entry.x),
+            Reverse(context.entries[0].grid_entry.y),
+            Reverse(context.entries[0].grid_entry.id),
+        )
+    });
+
+    // other stuff that ought to happen here:
+    // - deduplication? if we have the same mask, same stack, better relevance, we should prefer it
+    // - the thing where we don't allow jumps down in relevance that are bigger than 0.25
+    // - way smarter stopping earlier, sorting, cutting off, etc.
+    // - there's a relevance penalty for ascending vs. descending stuff for some reason... maybe
+    //   we just shouldn't do that anymore though?
+    contexts.truncate(MAX_CONTEXTS * 40);
+
+    Ok(contexts)
+}
+
+fn tree_coalesce_single<T: Borrow<GridStore> + Clone, U: Iterator<Item = MatchEntry>>(
+    subquery: &PhrasematchResults<T>,
+    match_opts: &MatchOpts,
+    grids: U
+) -> Result<impl Iterator<Item = CoalesceContext>, Error> {
+    let bigger_max = 2 * MAX_CONTEXTS;
+
+    let mut max_relevance: f64 = 0.;
+    let mut previous_id: u32 = 0;
+    let mut previous_relevance: f64 = 0.;
+    let mut previous_scoredist: f64 = 0.;
+    let mut min_scoredist = std::f64::MAX;
+    let mut feature_count: usize = 0;
+
+    let mut coalesced: HashMap<u32, CoalesceEntry> = HashMap::new();
+
+    for grid in grids {
+        let coalesce_entry = grid_to_coalesce_entry_alt(&grid, subquery, match_opts);
+
+        // If it's the same feature as the last one, but a lower scoredist don't add it
+        if previous_id == coalesce_entry.grid_entry.id
+            && coalesce_entry.scoredist <= previous_scoredist
+        {
+            continue;
+        }
+
+        if feature_count > bigger_max {
+            if coalesce_entry.scoredist < min_scoredist {
+                continue;
+            } else if coalesce_entry.grid_entry.relev < previous_relevance {
+                // Grids should be sorted by relevance coming out of get_matching,
+                // so if it's lower than the last relevance, stop
+                break;
+            }
+        }
+
+        if max_relevance - coalesce_entry.grid_entry.relev >= 0.25 {
+            break;
+        }
+        if coalesce_entry.grid_entry.relev > max_relevance {
+            max_relevance = coalesce_entry.grid_entry.relev;
+        }
+
+        // Save current values before mocing into coalesced
+        let current_id = coalesce_entry.grid_entry.id;
+        let current_relev = coalesce_entry.grid_entry.relev;
+        let current_scoredist = coalesce_entry.scoredist;
+
+        // If it's the same feature as one that's been added before, but a higher scoredist, update the entry
+        match coalesced.entry(current_id) {
+            Entry::Occupied(mut already_coalesced) => {
+                if current_scoredist > already_coalesced.get().scoredist
+                    && current_relev >= already_coalesced.get().grid_entry.relev
+                {
+                    already_coalesced.insert(coalesce_entry);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(coalesce_entry);
+            }
+        }
+
+        if previous_id != current_id {
+            feature_count += 1;
+        }
+        if match_opts.proximity.is_none() && feature_count > bigger_max {
+            break;
+        }
+        if current_scoredist < min_scoredist {
+            min_scoredist = current_scoredist;
+        }
+        previous_id = current_id;
+        previous_relevance = current_relev;
+        previous_scoredist = current_scoredist;
+    }
+
+    let contexts = coalesced
+        .into_iter()
+        .map(|(_, entry)| CoalesceContext {
+            entries: vec![entry.clone()],
+            mask: entry.mask,
+            relev: entry.grid_entry.relev,
+        });
+
+    Ok(contexts)
+}
+
+fn tree_recurse<T: Borrow<GridStore> + Clone + Debug>(
+    node: &StackableNode<T>,
+    match_opts: &MatchOpts,
+    prev_state: &TreeCoalesceState,
+    prev_zoom: u16,
+    mut contexts: &mut Vec<CoalesceContext>
+) -> Result<(), Error> {
+    for child in &node.children {
+        // we need lots of grids because we don't know where the things we're stacking on top
+        // will be
+        let subquery = child.phrasematch.as_ref().expect("phrasematch must be set on non-root tree nodes");
+
+        let mut zoom_adjusted_match_options = match_opts.clone();
+        if zoom_adjusted_match_options.zoom != subquery.zoom {
+            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.zoom);
+        }
+
+        let scale_factor: u16 = 1 << (subquery.zoom - prev_zoom);
+
+        let mut state: TreeCoalesceState = TreeCoalesceState::new();
+        let grids = subquery.store.borrow().streaming_get_matching(
+            &subquery.match_key,
+            &zoom_adjusted_match_options,
+            MAX_GRIDS_PER_PHRASE,
+        )?;
+
+        for grid in grids.take(MAX_GRIDS_PER_PHRASE) {
+            let prev_zoom_xy = (
+                grid.grid_entry.x / scale_factor,
+                grid.grid_entry.y / scale_factor,
+            );
+
+            if let Some(already_coalesced) = prev_state.get(&prev_zoom_xy) {
+                let entry = grid_to_coalesce_entry_alt(&grid, subquery, match_opts);
+                for parent_context in already_coalesced {
+                    let mut new_context = parent_context.clone();
+                    new_context.entries.push(entry.clone());
+                    new_context.mask = new_context.mask | subquery.mask;
+                    new_context.relev += new_context.relev;
+
+                    contexts.push(new_context.clone());
+
+                    if child.children.len() > 0 {
+                        // only bother with getting ready to recurse if we have any children to
+                        // operate on
+                        let state_vec = state.entry((grid.grid_entry.x, grid.grid_entry.y)).or_insert_with(|| vec![]);
+                        state_vec.push(new_context);
+                    }
+                }
+            }
+        }
+        if state.len() > 0 {
+            tree_recurse(&child, match_opts, &state, subquery.zoom, &mut contexts)?;
+        }
+    }
+    Ok(())
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -386,7 +386,7 @@ pub struct CoalesceEntry {
     pub scoredist: f64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialOrd, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialOrd, PartialEq, Clone)]
 pub struct CoalesceContext {
     pub mask: u32,
     pub relev: f64,
@@ -416,11 +416,11 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub prefix: u8,
     pub weight: f64,
     pub match_key: MatchKey,
-    pub idx: u32,
+    pub idx: u16,
     pub zoom: u16,
     pub nmask: u32,
     pub mask: u32,
-    pub bmask: HashSet<u32>,
+    pub bmask: HashSet<u16>,
     pub edit_multiplier: f64,
     pub subquery_edit_distance: u8,
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -384,6 +384,7 @@ pub struct CoalesceEntry {
     pub mask: u32,
     pub distance: f64,
     pub scoredist: f64,
+    pub phrasematch_id: u32,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialOrd, PartialEq, Clone)]
@@ -412,7 +413,7 @@ pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
 pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     #[serde(serialize_with = "serialize_path")]
     pub store: T,
-    pub scorefactor: u16,
+    pub scorefactor: u32,
     pub prefix: u8,
     pub weight: f64,
     pub match_key: MatchKey,
@@ -423,6 +424,7 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub bmask: HashSet<u16>,
     pub edit_multiplier: f64,
     pub subquery_edit_distance: u8,
+    pub id: u32,
 }
 
 impl<T: Borrow<GridStore> + Clone> From<PhrasematchResults<T>> for PhrasematchSubquery<T> {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -425,6 +425,19 @@ pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
     pub subquery_edit_distance: u8,
 }
 
+impl<T: Borrow<GridStore> + Clone> From<PhrasematchResults<T>> for PhrasematchSubquery<T> {
+    fn from(phrasematch_results: PhrasematchResults<T>) -> Self {
+        PhrasematchSubquery {
+            store: phrasematch_results.store,
+            weight: phrasematch_results.weight,
+            match_key: phrasematch_results.match_key,
+            idx: phrasematch_results.idx,
+            zoom: phrasematch_results.zoom,
+            mask: phrasematch_results.mask,
+        }
+    }
+}
+
 #[inline]
 pub fn relev_float_to_int(relev: f64) -> u8 {
     if relev == 0.4 {

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -7,7 +7,7 @@ mod stackable;
 mod store;
 
 pub use builder::*;
-pub use coalesce::{coalesce, tree_coalesce};
+pub use coalesce::{coalesce, stack_and_coalesce, tree_coalesce};
 pub use common::*;
 pub use stackable::stackable;
 pub use store::*;

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -7,7 +7,7 @@ mod stackable;
 mod store;
 
 pub use builder::*;
-pub use coalesce::coalesce;
+pub use coalesce::{coalesce, tree_coalesce};
 pub use common::*;
 pub use stackable::stackable;
 pub use store::*;

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -15,9 +15,9 @@ pub struct StackableNode<T: Borrow<GridStore> + Clone + Debug> {
     pub phrasematch: Option<PhrasematchResults<T>>,
     pub children: Vec<StackableNode<T>>,
     pub nmask: u32,
-    pub bmask: HashSet<u32>,
+    pub bmask: HashSet<u16>,
     pub mask: u32,
-    pub idx: u32,
+    pub idx: u16,
     pub max_relev: f64,
     pub adjusted_relev: f64,
     pub zoom: u16,
@@ -27,9 +27,9 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
     phrasematch_results: &Vec<Vec<PhrasematchResults<T>>>,
     phrasematch_result: Option<PhrasematchResults<T>>,
     nmask: u32,
-    bmask: HashSet<u32>,
+    bmask: HashSet<u16>,
     mask: u32,
-    idx: u32,
+    idx: u16,
     max_relev: f64,
     adjusted_relev: f64,
     zoom: u16,
@@ -62,8 +62,8 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
             {
                 let target_nmask = &phrasematches.nmask | node.nmask;
                 let target_mask = &phrasematches.mask | node.mask;
-                let mut target_bmask: HashSet<u32> = node.bmask.iter().cloned().collect();
-                let phrasematch_bmask: HashSet<u32> = phrasematches.bmask.iter().cloned().collect();
+                let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
+                let phrasematch_bmask: HashSet<u16> = phrasematches.bmask.iter().cloned().collect();
                 target_bmask.extend(&phrasematch_bmask);
                 let target_relev = 0.0 + &phrasematches.weight;
                 let target_adjusted_relev =

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -48,11 +48,13 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
 
     for phrasematch_per_index in phrasematch_results.iter() {
         for phrasematches in phrasematch_per_index.iter() {
-            if node.zoom > phrasematches.zoom {
-                continue;
-            } else if node.zoom == phrasematches.zoom {
-                if node.idx < phrasematches.idx {
+            if node.phrasematch.is_some() {
+                if node.zoom > phrasematches.zoom {
                     continue;
+                } else if node.zoom == phrasematches.zoom {
+                    if node.idx > phrasematches.idx {
+                        continue;
+                    }
                 }
             }
 

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -115,6 +115,7 @@ mod test {
         let store = GridStore::new(directory.path()).unwrap();
 
         let a1 = PhrasematchResults {
+            id: 0,
             store: &store,
             scorefactor: 0,
             prefix: 0,
@@ -130,6 +131,7 @@ mod test {
         };
 
         let b1 = PhrasematchResults {
+            id: 0,
             store: &store,
             scorefactor: 0,
             prefix: 0,
@@ -145,6 +147,7 @@ mod test {
         };
 
         let b2 = PhrasematchResults {
+            id: 0,
             store: &store,
             scorefactor: 0,
             prefix: 0,

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -252,7 +252,8 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
                     tmp_id: 33554433,
                     mask: 1,
                     distance: 0,
-                    scoredist: 1
+                    scoredist: 1,
+                    phrasematch_id: 0,
                 }
             ], 'Ok, finds the right grid entry');
         t.equal(res.length, 3, 'Result set has 3 grid entries');
@@ -470,7 +471,7 @@ tape('Deserialize phrasematch results', (t) => {
     let phrasematchResults = [
         {
             'phrasematches': [
-                new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0])
+                new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1)
             ],
             idx: 0,
             nmask: 14,
@@ -483,7 +484,7 @@ tape('Deserialize phrasematch results', (t) => {
 
 
 
-function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, edit_multiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages) {
+function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, editMultiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages, id) {
     this.store = store;
     this.subquery = subquery;
     this.phrase = phrase;
@@ -493,7 +494,7 @@ function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefact
     this.scorefactor = scorefactor;
     this.prefix = prefix;
     this.zoom = zoom;
-    this.edit_multiplier = edit_multiplier || 1;
+    this.editMultiplier = editMultiplier || 1;
     this.prox_match = prox_match || false;
     this.cat_match = cat_match || false;
     this.partial_number = partial_number || false;
@@ -501,6 +502,7 @@ function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefact
     this.original_phrase = original_phrase;
     this.original_phrase_ender = original_phrase_ender;
     this.original_phrase_mask = original_phrase_mask;
+    this.id = id;
 
     if (languages) {
         // carmen-cache gives special treatment to the "languages" property
@@ -521,7 +523,7 @@ function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefact
 }
 
 Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.store, this.subquery.slice(), this.phrase, this.weight, this.phrase_id_range, this.scorefactor, this.prefix, this.mask, this.zoom, this.edit_multiplier, this.prox_match, this.cat_match, this.partial_number, this.subquery_edit_distance, this.original_phrase, this.original_phrase_ender, this.original_phrase_mask, this.languages);
+    return new Phrasematch(this.store, this.subquery.slice(), this.phrase, this.weight, this.phrase_id_range, this.scorefactor, this.prefix, this.mask, this.zoom, this.editMultiplier, this.prox_match, this.cat_match, this.partial_number, this.subquery_edit_distance, this.original_phrase, this.original_phrase_ender, this.original_phrase_mask, this.languages, this.id);
 };
 
 module.exports.Phrasematch = Phrasematch;

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -24,6 +24,7 @@ fn coalesce_single_test_proximity_quadrants() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -127,6 +128,7 @@ fn coalesce_single_test_proximity_basic() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -185,6 +187,7 @@ fn coalesce_single_test_language_penalty() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -255,6 +258,7 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueries with different language set from grids, with proximity");
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -272,6 +276,7 @@ fn coalesce_multi_test_language_penalty() {
             mask: 1 << 0,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -335,6 +340,7 @@ fn coalesce_single_test() {
         ],
     }]);
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -429,6 +435,7 @@ fn coalesce_single_test() {
             mask: 1 << 0,
             relev: 1.,
             entries: vec![CoalesceEntry {
+                phrasematch_id: 0,
                 matches_language: true,
                 idx: 1,
                 tmp_id: 33554435,
@@ -453,6 +460,7 @@ fn coalesce_single_test() {
             mask: 1 << 0,
             relev: 1.,
             entries: vec![CoalesceEntry {
+                phrasematch_id: 0,
                 matches_language: true,
                 idx: 1,
                 tmp_id: 33554433,
@@ -477,6 +485,7 @@ fn coalesce_single_test() {
             mask: 1 << 0,
             relev: 0.8,
             entries: vec![CoalesceEntry {
+                phrasematch_id: 0,
                 matches_language: true,
                 idx: 1,
                 tmp_id: 33554434,
@@ -512,6 +521,7 @@ fn coalesce_single_test() {
             mask: 1 << 0,
             relev: 1.,
             entries: vec![CoalesceEntry {
+                phrasematch_id: 0,
                 matches_language: true,
                 idx: 1,
                 tmp_id: 33554433,
@@ -549,6 +559,7 @@ fn coalesce_single_test() {
             mask: 1 << 0,
             relev: 1.,
             entries: vec![CoalesceEntry {
+                phrasematch_id: 0,
                 matches_language: true,
                 idx: 1,
                 tmp_id: 33554433,
@@ -589,6 +600,7 @@ fn coalesce_single_languages_test() {
     // Test query with all languages
     println!("Coalesce single - all languages");
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -636,6 +648,7 @@ fn coalesce_single_languages_test() {
     // Test lanuage 0
     println!("Coalesce single - language 0, language matching 2 grids");
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -683,6 +696,7 @@ fn coalesce_single_languages_test() {
     println!("Coalesce single - language 3, language matching no grids");
 
     let subquery = PhrasematchResults {
+        id: 0,
         scorefactor: 0,
         prefix: 0,
         nmask: 1,
@@ -751,6 +765,7 @@ fn coalesce_multi_test() {
 
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -768,6 +783,7 @@ fn coalesce_multi_test() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -799,6 +815,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[0].entries[0],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 1,
             tmp_id: 33554434,
@@ -819,6 +836,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[0].entries[1],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 0,
             tmp_id: 1,
@@ -842,6 +860,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[1].entries[0],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 1,
             tmp_id: 33554435,
@@ -862,6 +881,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[0].entries[1],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 0,
             tmp_id: 1,
@@ -897,6 +917,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[0].entries[0],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 1,
             tmp_id: 33554435,
@@ -917,6 +938,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[0].entries[1],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 0,
             tmp_id: 1,
@@ -938,6 +960,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[1].entries[0],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 1,
             tmp_id: 33554434,
@@ -958,6 +981,7 @@ fn coalesce_multi_test() {
     assert_eq!(
         result[1].entries[1],
         CoalesceEntry {
+            phrasematch_id: 0,
             matches_language: true,
             idx: 0,
             tmp_id: 1,
@@ -1017,6 +1041,7 @@ fn coalesce_multi_languages_test() {
     println!("Coalesce multi - all languages");
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1034,6 +1059,7 @@ fn coalesce_multi_languages_test() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -1082,6 +1108,7 @@ fn coalesce_multi_languages_test() {
     println!("Coalesce multi - language 0");
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1099,6 +1126,7 @@ fn coalesce_multi_languages_test() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -1147,6 +1175,7 @@ fn coalesce_multi_languages_test() {
     println!("Coalsece multi - language 3");
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1164,6 +1193,7 @@ fn coalesce_multi_languages_test() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -1228,6 +1258,7 @@ fn coalesce_multi_scoredist() {
 
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1245,6 +1276,7 @@ fn coalesce_multi_scoredist() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -1329,6 +1361,7 @@ fn coalesce_multi_test_bbox() {
 
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1346,6 +1379,7 @@ fn coalesce_multi_test_bbox() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,
@@ -1423,6 +1457,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at lower zoom than either of the expected results");
     let stack = vec![
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 1,
@@ -1440,6 +1475,7 @@ fn coalesce_multi_test_bbox() {
             mask: 1 << 1,
         },
         PhrasematchResults {
+            id: 0,
             scorefactor: 0,
             prefix: 0,
             nmask: 2,

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -24,7 +24,12 @@ fn coalesce_single_test_proximity_quadrants() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -41,9 +46,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -58,9 +63,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -75,9 +80,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -92,9 +97,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -122,7 +127,12 @@ fn coalesce_single_test_proximity_basic() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -137,9 +147,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     assert_eq!(
@@ -175,7 +185,12 @@ fn coalesce_single_test_language_penalty() {
 
     let store = GridStore::new(directory.path()).unwrap();
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 },
@@ -190,9 +205,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 1., "Contexts inside the proximity radius don't get a cross langauge penalty");
@@ -205,9 +220,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 0.96, "With no proximity, cross language contexts get a penalty");
@@ -240,7 +255,12 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueries with different language set from grids, with proximity");
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -252,7 +272,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 0,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -271,9 +296,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 1., "Contexts inside the proximity radius don't get a cross langauge penalty");
@@ -288,9 +313,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 0.96, "Cross language contexts get a penalty");
@@ -310,7 +335,12 @@ fn coalesce_single_test() {
         ],
     }]);
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -324,9 +354,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -384,9 +414,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st result is the closest, even if its a slightly lower score");
@@ -471,9 +501,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
     assert_eq!(result[0].entries[0].grid_entry.id, 1, "Result is the one that's within the bbox");
     assert_eq!(
@@ -509,9 +539,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
         proximity: Some(Proximity { point: [1, 1], radius: 40. }),
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
     assert_eq!(
         result[0],
@@ -559,7 +589,12 @@ fn coalesce_single_languages_test() {
     // Test query with all languages
     println!("Coalesce single - all languages");
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -573,9 +608,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -601,7 +636,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     // Test lanuage 0
     println!("Coalesce single - language 0, language matching 2 grids");
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -615,9 +655,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -643,7 +683,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce single - language 3, language matching no grids");
 
     let subquery = PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+        scorefactor: 0,
+        prefix: 0,
+        nmask: 1,
+        bmask: HashSet::new(),
+        edit_multiplier: 1.0,
+        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -657,9 +702,9 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -706,7 +751,12 @@ fn coalesce_multi_test() {
 
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -718,7 +768,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -735,9 +790,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
     assert_eq!(result[0].mask, 3, "1st result context has correct mask");
     assert_eq!(result[0].entries.len(), 2, "1st result has 2 coalesce entries");
@@ -833,9 +888,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
     assert_eq!(result[0].mask, 3, "1st result context has correct mask");
     assert_eq!(result[0].entries.len(), 2, "1st result has 2 coalesce entries");
@@ -962,7 +1017,12 @@ fn coalesce_multi_languages_test() {
     println!("Coalesce multi - all languages");
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -974,7 +1034,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -989,9 +1054,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -1017,7 +1082,12 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - language 0");
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1029,7 +1099,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1044,9 +1119,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -1072,7 +1147,12 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalsece multi - language 3");
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1084,7 +1164,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1099,9 +1184,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -1143,7 +1228,12 @@ fn coalesce_multi_scoredist() {
 
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1155,7 +1245,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1175,9 +1270,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
     assert_eq!(result[1].entries[0].grid_entry.id, 2, "Farther feature is 2nd");
     assert_eq!(
@@ -1194,9 +1289,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
     assert_eq!(result[1].entries[0].grid_entry.id, 2, "Closer feature with lower score is 2nd");
     assert_eq!(
@@ -1234,7 +1329,12 @@ fn coalesce_multi_test_bbox() {
 
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1246,7 +1346,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1262,9 +1367,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	// assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1280,9 +1385,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	// assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1299,9 +1404,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	// assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1318,7 +1423,12 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     println!("Coalesce multi - bbox at lower zoom than either of the expected results");
     let stack = vec![
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 1,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1330,7 +1440,12 @@ scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0
             mask: 1 << 1,
         },
         PhrasematchResults {
-scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
+            scorefactor: 0,
+            prefix: 0,
+            nmask: 2,
+            bmask: HashSet::new(),
+            edit_multiplier: 1.0,
+            subquery_edit_distance: 0,
             store: &store3,
             weight: 0.5,
             match_key: MatchKey {
@@ -1344,9 +1459,9 @@ scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
-	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
-	// assert_eq!(result, tree_result);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -1,6 +1,8 @@
 use carmen_core::gridstore::*;
 use test_utils::*;
 
+use std::collections::HashSet;
+
 const ALL_LANGUAGES: u128 = u128::max_value();
 
 #[test]
@@ -21,7 +23,8 @@ fn coalesce_single_test_proximity_quadrants() {
     builder.finish().unwrap();
 
     let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -37,7 +40,10 @@ fn coalesce_single_test_proximity_quadrants() {
         proximity: Some(Proximity { point: [110, 115], radius: 200. }), // NE proximity point
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -51,7 +57,10 @@ fn coalesce_single_test_proximity_quadrants() {
         proximity: Some(Proximity { point: [110, 85], radius: 200. }), // SE proximity point
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -65,7 +74,10 @@ fn coalesce_single_test_proximity_quadrants() {
         proximity: Some(Proximity { point: [90, 85], radius: 200. }), // SW proximity point
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -79,7 +91,10 @@ fn coalesce_single_test_proximity_quadrants() {
         proximity: Some(Proximity { point: [90, 115], radius: 200. }), // NW proximity point
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     let result_distances: Vec<f64> =
@@ -106,7 +121,8 @@ fn coalesce_single_test_proximity_basic() {
     builder.finish().unwrap();
 
     let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -120,7 +136,10 @@ fn coalesce_single_test_proximity_basic() {
         proximity: Some(Proximity { point: [2, 2], radius: 400. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
         result.iter().map(|context| context.entries[0].grid_entry.id).collect();
     assert_eq!(
@@ -155,7 +174,8 @@ fn coalesce_single_test_language_penalty() {
     builder.finish().unwrap();
 
     let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 },
@@ -169,7 +189,10 @@ fn coalesce_single_test_language_penalty() {
         proximity: Some(Proximity { point: [2, 2], radius: 1. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 1., "Contexts inside the proximity radius don't get a cross langauge penalty");
@@ -181,7 +204,10 @@ fn coalesce_single_test_language_penalty() {
     }
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 0.96, "With no proximity, cross language contexts get a penalty");
@@ -213,7 +239,8 @@ fn coalesce_multi_test_language_penalty() {
     // Subqueries with a different language set
     println!("Coalesce multi - Subqueries with different language set from grids, with proximity");
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -224,7 +251,8 @@ fn coalesce_multi_test_language_penalty() {
             zoom: 14,
             mask: 1 << 0,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -242,7 +270,10 @@ fn coalesce_multi_test_language_penalty() {
         proximity: Some(Proximity { point: [2, 2], radius: 1. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 1., "Contexts inside the proximity radius don't get a cross langauge penalty");
@@ -256,7 +287,10 @@ fn coalesce_multi_test_language_penalty() {
     }
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].relev, 0.96, "Cross language contexts get a penalty");
@@ -275,7 +309,8 @@ fn coalesce_single_test() {
             GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
     }]);
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
@@ -288,7 +323,10 @@ fn coalesce_single_test() {
     // Test default opts - no proximity or bbox
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -345,7 +383,10 @@ fn coalesce_single_test() {
         proximity: Some(Proximity { point: [3, 3], radius: 40. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result[0].entries[0].grid_entry.id, 3, "1st result is the closest, even if its a slightly lower score");
@@ -429,7 +470,10 @@ fn coalesce_single_test() {
     // Test with bbox
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
     assert_eq!(result[0].entries[0].grid_entry.id, 1, "Result is the one that's within the bbox");
     assert_eq!(
@@ -464,7 +508,10 @@ fn coalesce_single_test() {
         bbox: Some([1, 1, 1, 1]),
         proximity: Some(Proximity { point: [1, 1], radius: 40. }),
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
     assert_eq!(
         result[0],
@@ -511,7 +558,8 @@ fn coalesce_single_languages_test() {
     let store = GridStore::new(directory.path()).unwrap();
     // Test query with all languages
     println!("Coalesce single - all languages");
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -524,7 +572,10 @@ fn coalesce_single_languages_test() {
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -549,7 +600,8 @@ fn coalesce_single_languages_test() {
 
     // Test lanuage 0
     println!("Coalesce single - language 0, language matching 2 grids");
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -562,7 +614,10 @@ fn coalesce_single_languages_test() {
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -587,7 +642,8 @@ fn coalesce_single_languages_test() {
 
     println!("Coalesce single - language 3, language matching no grids");
 
-    let subquery = PhrasematchSubquery {
+    let subquery = PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
@@ -600,7 +656,10 @@ fn coalesce_single_languages_test() {
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
 
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
@@ -646,7 +705,8 @@ fn coalesce_multi_test() {
     }]);
 
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -657,7 +717,8 @@ fn coalesce_multi_test() {
             zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -673,7 +734,10 @@ fn coalesce_multi_test() {
     // Test coalesce multi with no proximity or bbox
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
     assert_eq!(result[0].mask, 3, "1st result context has correct mask");
     assert_eq!(result[0].entries.len(), 2, "1st result has 2 coalesce entries");
@@ -768,7 +832,10 @@ fn coalesce_multi_test() {
         proximity: Some(Proximity { point: [3, 3], radius: 40. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
     assert_eq!(result[0].mask, 3, "1st result context has correct mask");
     assert_eq!(result[0].entries.len(), 2, "1st result has 2 coalesce entries");
@@ -894,7 +961,8 @@ fn coalesce_multi_languages_test() {
     // Test ALL LANGUAGES
     println!("Coalesce multi - all languages");
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -905,7 +973,8 @@ fn coalesce_multi_languages_test() {
             zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -919,7 +988,10 @@ fn coalesce_multi_languages_test() {
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -944,7 +1016,8 @@ fn coalesce_multi_languages_test() {
     // Test language 0
     println!("Coalesce multi - language 0");
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -955,7 +1028,8 @@ fn coalesce_multi_languages_test() {
             zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -969,7 +1043,10 @@ fn coalesce_multi_languages_test() {
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -994,7 +1071,8 @@ fn coalesce_multi_languages_test() {
     // Test language 3
     println!("Coalsece multi - language 3");
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1005,7 +1083,8 @@ fn coalesce_multi_languages_test() {
             zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1019,7 +1098,10 @@ fn coalesce_multi_languages_test() {
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
     {
         assert_eq!(result.len(), 2, "Two results are returned");
@@ -1060,7 +1142,8 @@ fn coalesce_multi_scoredist() {
     }]);
 
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1071,7 +1154,8 @@ fn coalesce_multi_scoredist() {
             zoom: 0,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1090,7 +1174,10 @@ fn coalesce_multi_scoredist() {
         proximity: Some(Proximity { point: [4601, 6200], radius: 40. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
     assert_eq!(result[1].entries[0].grid_entry.id, 2, "Farther feature is 2nd");
     assert_eq!(
@@ -1106,7 +1193,10 @@ fn coalesce_multi_scoredist() {
         proximity: Some(Proximity { point: [4610, 6200], radius: 40. }),
         ..MatchOpts::default()
     };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
     assert_eq!(result[1].entries[0].grid_entry.id, 2, "Closer feature with lower score is 2nd");
     assert_eq!(
@@ -1143,7 +1233,8 @@ fn coalesce_multi_test_bbox() {
     }]);
 
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
@@ -1154,7 +1245,8 @@ fn coalesce_multi_test_bbox() {
             zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1169,7 +1261,10 @@ fn coalesce_multi_test_bbox() {
     // Test bbox at zoom 1 that should contain 2 grids
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	// assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1184,7 +1279,10 @@ fn coalesce_multi_test_bbox() {
     // Test bbox at zoom 2 that should contain 2 grids
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	// assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1200,7 +1298,10 @@ fn coalesce_multi_test_bbox() {
     // Test bbox at zoom 6 that should contain 2 grids
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	// assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1216,7 +1317,8 @@ fn coalesce_multi_test_bbox() {
     // Test bbox at lower zoom than either of the expected results
     println!("Coalesce multi - bbox at lower zoom than either of the expected results");
     let stack = vec![
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 1, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
@@ -1227,7 +1329,8 @@ fn coalesce_multi_test_bbox() {
             zoom: 2,
             mask: 1 << 1,
         },
-        PhrasematchSubquery {
+        PhrasematchResults {
+scorefactor: 0, prefix: 0, nmask: 2, bmask: HashSet::new(), edit_multiplier: 1.0, subquery_edit_distance: 0,
             store: &store3,
             weight: 0.5,
             match_key: MatchKey {
@@ -1240,7 +1343,10 @@ fn coalesce_multi_test_bbox() {
         },
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
-    let result = coalesce(stack.clone(), &match_opts).unwrap();
+    let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
+	let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+	let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+	// assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
     assert_eq!(
         (result[0].entries[0].grid_entry.x, result[0].entries[0].grid_entry.y),
@@ -1252,6 +1358,19 @@ fn coalesce_multi_test_bbox() {
         (21, 7),
         "Bbox [1,0,0,1,0] - 2nd result is xzy 5/20/7"
     );
+}
+
+#[cfg(test)]
+fn truncate_coalesce_results(results: Vec<CoalesceContext>) -> Vec<CoalesceContext> {
+    let mut new_results = Vec::new();
+    let max_relevance = if results.len() == 0 { 1.0 } else { results[0].relev };
+    for r in results {
+        if max_relevance - r.relev < 0.25 {
+            let context = r.clone();
+            new_results.push(context);
+        }
+    }
+    new_results
 }
 
 // TODO: add proximity test with max score


### PR DESCRIPTION
Two big things in here:

## A new version of coalesce that operates on the trees produced by the new stackable function

There's a new function, `tree_coalesce` that operates on stacks. It identifies what would have been single-item stacks (basically, descendants of the root that have no children), and does something similar to the old coalesce_single, which does a very limited index scan, and for all other cases, instead of the old coalesce_multi, it does a recursive exploration of the descendants of the root, accumulating state at each recursion step.

At present this function isn't parallel at all, and exhaustively explores the entire tree, which we'll want to change in subsequent PRs.

## A combined stack-and-coalesce function

In Carmen we want to move to having spatialmatch call a function with all of its phrasematches that does both the stackable work and the coalesce work, so this branch adds that composite function, `stackable_and_coalesce` (camel case in the binding). Right now it's pretty basic, but eventually we'll want to do some deduping, etc. It also adds bindings for JS.

In addition to all that, there are some extra odds and ends to match new expectations on the Carmen side or to get Carmen tests to pass.