### PR TITLE
Refactor phrasematch types

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,6 +17,7 @@ neon-build = "0.2.0"
 [dependencies]
 neon = "0.2.0"
 neon-serde = "0.1.1"
+serde = "1.*"
 failure = "0.1.5"
 owning_ref = "0.4"
 carmen-core = { path = "../" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -462,8 +462,6 @@ where
             gridstore_clone
         };
         let weight = js_phrasematch.get(cx, "weight")?;
-        let idx = js_phrasematch.get(cx, "idx")?;
-        let zoom = js_phrasematch.get(cx, "zoom")?;
         let mask = js_phrasematch.get(cx, "mask")?;
 
         let match_key = js_phrasematch.get(cx, "match_key")?.downcast::<JsObject>().or_throw(cx)?;
@@ -504,9 +502,6 @@ fn deserialize_phrasematch_results<'j, C: Context<'j>>(
     for i in 0..js_phrasematch_per_index.len() {
         let js_phrasematch = js_phrasematch_per_index.get(cx, i)?.downcast::<JsObject>().or_throw(cx)?;
         let phrasematch_array = js_phrasematch.get(cx, "phrasematches")?.downcast::<JsArray>().or_throw(cx)?;
-        let nmask = js_phrasematch.get(cx, "nmask")?;
-        let idx = js_phrasematch.get(cx, "idx")?;
-        let bmask = js_phrasematch.get(cx, "bmask")?;
 
         let phrasematch_array_length = phrasematch_array.len();
         let mut phrasematches: Vec<PhrasematchSubquery<ArcGridStore>> = Vec::with_capacity(phrasematch_array_length as usize);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-stack-and-coalesce-2",
+  "version": "0.1.1-stack-and-coalesce-3",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-stack-and-coalesce-3",
+  "version": "0.1.1-stack-and-coalesce-4",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-stack-and-coalesce-1",
+  "version": "0.1.1-stack-and-coalesce-2",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -590,11 +590,11 @@ fn tree_recurse<T: Borrow<GridStore> + Clone + Debug>(
 }
 
 pub fn stack_and_coalesce<T: Borrow<GridStore> + Clone + Debug>(
-    phrasematches: &Vec<Vec<PhrasematchSubquery<T>>>,
+    phrasematches: &Vec<PhrasematchSubquery<T>>,
     match_opts: &MatchOpts,
 ) -> Result<Vec<CoalesceContext>, Error> {
     // currently stackable requires double-wrapping the phrasematches vector, which requires an
     // extra clone; ideally we wouldn't do that
-    let tree = stackable(&phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     tree_coalesce(&tree, &match_opts)
 }

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -52,14 +52,14 @@ fn grid_to_coalesce_entry<T: Borrow<GridStore> + Clone>(
     phrasematch_id: u32,
 ) -> CoalesceEntry {
     // Zoom has been adjusted in coalesce_multi, or correct zoom has been passed in for coalesce_single
-    debug_assert!(match_opts.zoom == subquery.zoom);
+    debug_assert!(match_opts.zoom == subquery.store.borrow().zoom);
     let relevance = grid.grid_entry.relev * subquery.weight;
 
     CoalesceEntry {
         grid_entry: GridEntry { relev: relevance, ..grid.grid_entry },
         matches_language: grid.matches_language,
-        idx: subquery.idx,
-        tmp_id: ((subquery.idx as u32) << 25) + grid.grid_entry.id,
+        idx: subquery.store.borrow().idx,
+        tmp_id: ((subquery.store.borrow().idx as u32) << 25) + grid.grid_entry.id,
         mask: subquery.mask,
         distance: grid.distance,
         scoredist: grid.scoredist,
@@ -174,7 +174,7 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
     mut stack: Vec<PhrasematchSubquery<T>>,
     match_opts: &MatchOpts,
 ) -> Result<Vec<CoalesceContext>, Error> {
-    stack.sort_by_key(|subquery| (subquery.zoom, subquery.idx));
+    stack.sort_by_key(|subquery| (subquery.store.borrow().zoom, subquery.store.borrow().idx));
 
     let mut coalesced: HashMap<(u16, u16, u16), Vec<CoalesceContext>> = HashMap::new();
     let mut contexts: Vec<CoalesceContext> = Vec::new();
@@ -189,17 +189,19 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
         let compatible_zooms: Vec<u16> = stack
             .iter()
             .filter_map(|subquery_b| {
-                if subquery.idx == subquery_b.idx || subquery.zoom < subquery_b.zoom {
+                if subquery.store.borrow().idx == subquery_b.store.borrow().idx
+                    || subquery.store.borrow().zoom < subquery_b.store.borrow().zoom
+                {
                     None
                 } else {
-                    Some(subquery_b.zoom)
+                    Some(subquery_b.store.borrow().zoom)
                 }
             })
             .dedup()
             .collect();
 
-        if zoom_adjusted_match_options.zoom != subquery.zoom {
-            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.zoom);
+        if zoom_adjusted_match_options.zoom != subquery.store.borrow().zoom {
+            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.store.borrow().zoom);
         }
 
         let grids = subquery.store.borrow().streaming_get_matching(
@@ -212,7 +214,7 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
             let coalesce_entry =
                 grid_to_coalesce_entry(&grid, subquery, &zoom_adjusted_match_options, 0);
 
-            let zxy = (subquery.zoom, grid.grid_entry.x, grid.grid_entry.y);
+            let zxy = (subquery.store.borrow().zoom, grid.grid_entry.x, grid.grid_entry.y);
 
             let mut context_mask = coalesce_entry.mask;
             let mut context_relevance = coalesce_entry.grid_entry.relev;
@@ -221,7 +223,7 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
             // See which other zooms are compatible.
             // These should all be lower zooms, so "zoom out" by dividing by 2^(difference in zooms)
             for other_zoom in compatible_zooms.iter() {
-                let scale_factor: u16 = 1 << (subquery.zoom - *other_zoom);
+                let scale_factor: u16 = 1 << (subquery.store.borrow().zoom - *other_zoom);
                 let other_zxy = (
                     *other_zoom,
                     entries[0].grid_entry.x / scale_factor,
@@ -341,13 +343,12 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
     let mut contexts: Vec<CoalesceContext> = Vec::new();
 
     for node in &stack_tree.children {
-        let subq_results =
+        let subquery =
             node.phrasematch.as_ref().expect("phrasematch must be set on non-root tree nodes");
-        let subquery: PhrasematchSubquery<T> = subq_results.clone().into();
 
         let mut zoom_adjusted_match_options = match_opts.clone();
-        if zoom_adjusted_match_options.zoom != subquery.zoom {
-            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.zoom);
+        if zoom_adjusted_match_options.zoom != subquery.store.borrow().zoom {
+            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.store.borrow().zoom);
         }
 
         if node.children.len() == 0 {
@@ -362,8 +363,7 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
                 bigger_max,
             )?;
 
-            let coalesced =
-                tree_coalesce_single(&subq_results, &zoom_adjusted_match_options, grids)?;
+            let coalesced = tree_coalesce_single(&subquery, &zoom_adjusted_match_options, grids)?;
 
             contexts.extend(coalesced);
         } else {
@@ -381,7 +381,7 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
                     &grid,
                     &subquery,
                     &zoom_adjusted_match_options,
-                    subq_results.id,
+                    subquery.id,
                 );
                 let context = CoalesceContext {
                     mask: subquery.mask,
@@ -398,7 +398,13 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
             }
 
             let mut multi_contexts = Vec::new();
-            tree_recurse(&node, match_opts, &prev_state, subquery.zoom, &mut multi_contexts)?;
+            tree_recurse(
+                &node,
+                match_opts,
+                &prev_state,
+                subquery.store.borrow().zoom,
+                &mut multi_contexts,
+            )?;
 
             // penalize singnle-entry stacks and ascending stacks for... some reason?
             for mut context in multi_contexts {
@@ -433,7 +439,7 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug>(
 }
 
 fn tree_coalesce_single<T: Borrow<GridStore> + Clone, U: Iterator<Item = MatchEntry>>(
-    subquery: &PhrasematchResults<T>,
+    subquery: &PhrasematchSubquery<T>,
     match_opts: &MatchOpts,
     grids: U,
 ) -> Result<impl Iterator<Item = CoalesceContext>, Error> {
@@ -449,7 +455,6 @@ fn tree_coalesce_single<T: Borrow<GridStore> + Clone, U: Iterator<Item = MatchEn
     let mut coalesced: HashMap<u32, CoalesceEntry> = HashMap::new();
 
     let phrasematch_id = subquery.id;
-    let subquery: PhrasematchSubquery<T> = subquery.clone().into();
 
     for grid in grids {
         let coalesce_entry = grid_to_coalesce_entry(&grid, &subquery, match_opts, phrasematch_id);
@@ -530,16 +535,15 @@ fn tree_recurse<T: Borrow<GridStore> + Clone + Debug>(
     for child in &node.children {
         // we need lots of grids because we don't know where the things we're stacking on top
         // will be
-        let subq_results =
+        let subquery =
             child.phrasematch.as_ref().expect("phrasematch must be set on non-root tree nodes");
-        let subquery: PhrasematchSubquery<T> = subq_results.clone().into();
 
         let mut zoom_adjusted_match_options = match_opts.clone();
-        if zoom_adjusted_match_options.zoom != subquery.zoom {
-            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.zoom);
+        if zoom_adjusted_match_options.zoom != subquery.store.borrow().zoom {
+            zoom_adjusted_match_options = match_opts.adjust_to_zoom(subquery.store.borrow().zoom);
         }
 
-        let scale_factor: u16 = 1 << (subquery.zoom - prev_zoom);
+        let scale_factor: u16 = 1 << (subquery.store.borrow().zoom - prev_zoom);
 
         let mut state: TreeCoalesceState = TreeCoalesceState::new();
         let grids = subquery.store.borrow().streaming_get_matching(
@@ -556,7 +560,7 @@ fn tree_recurse<T: Borrow<GridStore> + Clone + Debug>(
                     &grid,
                     &subquery,
                     &zoom_adjusted_match_options,
-                    subq_results.id,
+                    subquery.id,
                 );
                 for parent_context in already_coalesced {
                     let mut new_context = parent_context.clone();
@@ -579,18 +583,18 @@ fn tree_recurse<T: Borrow<GridStore> + Clone + Debug>(
             }
         }
         if state.len() > 0 {
-            tree_recurse(&child, match_opts, &state, subquery.zoom, &mut contexts)?;
+            tree_recurse(&child, match_opts, &state, subquery.store.borrow().zoom, &mut contexts)?;
         }
     }
     Ok(())
 }
 
 pub fn stack_and_coalesce<T: Borrow<GridStore> + Clone + Debug>(
-    phrasematches: &Vec<Vec<PhrasematchResults<T>>>,
+    phrasematches: &Vec<Vec<PhrasematchSubquery<T>>>,
     match_opts: &MatchOpts,
 ) -> Result<Vec<CoalesceContext>, Error> {
     // currently stackable requires double-wrapping the phrasematches vector, which requires an
     // extra clone; ideally we wouldn't do that
-    let tree = stackable(&phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     tree_coalesce(&tree, &match_opts)
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -404,40 +404,8 @@ pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
     pub store: T,
     pub weight: f64,
     pub match_key: MatchKey,
-    pub idx: u16,
-    pub zoom: u16,
     pub mask: u32,
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct PhrasematchResults<T: Borrow<GridStore> + Clone> {
-    #[serde(serialize_with = "serialize_path")]
-    pub store: T,
-    pub scorefactor: u32,
-    pub prefix: u8,
-    pub weight: f64,
-    pub match_key: MatchKey,
-    pub idx: u16,
-    pub zoom: u16,
-    pub nmask: u32,
-    pub mask: u32,
-    pub bmask: HashSet<u16>,
-    pub edit_multiplier: f64,
-    pub subquery_edit_distance: u8,
     pub id: u32,
-}
-
-impl<T: Borrow<GridStore> + Clone> From<PhrasematchResults<T>> for PhrasematchSubquery<T> {
-    fn from(phrasematch_results: PhrasematchResults<T>) -> Self {
-        PhrasematchSubquery {
-            store: phrasematch_results.store,
-            weight: phrasematch_results.weight,
-            match_key: phrasematch_results.match_key,
-            idx: phrasematch_results.idx,
-            zoom: phrasematch_results.zoom,
-            mask: phrasematch_results.mask,
-        }
-    }
 }
 
 #[inline]

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -117,10 +117,7 @@ impl MatchOpts {
                         // If this is a zoom out, divide by 2 for every level of zooming out.
                         let zoom_levels = self.zoom - target_z;
                         // Shifting to the right by a number is the same as dividing by 2 that number of times.
-                        Some([
-                            x >> zoom_levels,
-                            y >> zoom_levels,
-                        ])
+                        Some([x >> zoom_levels, y >> zoom_levels])
                     } else {
                         // If this is a zoom in, choose the closest to the middle of the possible tiles at the higher zoom level.
                         // The scale of the coordinates for zooming in is 2^(difference in zs).
@@ -180,11 +177,7 @@ mod tests {
     use once_cell::sync::Lazy;
 
     fn matchopts_proximity_generator(point: [u16; 2], zoom: u16) -> MatchOpts {
-        MatchOpts {
-            proximity: Some(point),
-            zoom: zoom,
-            ..MatchOpts::default()
-        }
+        MatchOpts { proximity: Some(point), zoom: zoom, ..MatchOpts::default() }
     }
 
     #[test]

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -179,9 +179,9 @@ mod tests {
     use super::*;
     use once_cell::sync::Lazy;
 
-    fn matchopts_proximity_generator(point: [u16; 2], radius: f64, zoom: u16) -> MatchOpts {
+    fn matchopts_proximity_generator(point: [u16; 2], zoom: u16) -> MatchOpts {
         MatchOpts {
-            proximity: Some(Proximity { point: point, radius: radius }),
+            proximity: Some(point),
             zoom: zoom,
             ..MatchOpts::default()
         }
@@ -190,9 +190,9 @@ mod tests {
     #[test]
     fn adjust_to_zoom_test_proximity() {
         static MATCH_OPTS_PROXIMITY: Lazy<(MatchOpts, MatchOpts, MatchOpts)> = Lazy::new(|| {
-            let match_opts1 = matchopts_proximity_generator([2, 28], 400., 14);
-            let match_opts2 = matchopts_proximity_generator([11, 25], 400., 6);
-            let match_opts3 = matchopts_proximity_generator([6, 6], 400., 4);
+            let match_opts1 = matchopts_proximity_generator([2, 28], 14);
+            let match_opts2 = matchopts_proximity_generator([11, 25], 6);
+            let match_opts3 = matchopts_proximity_generator([6, 6], 4);
             (match_opts1, match_opts2, match_opts3)
         });
 
@@ -201,42 +201,38 @@ mod tests {
             adjusted_match_opts1.zoom, 6,
             "Adjusted MatchOpts should have target zoom as zoom"
         );
-        assert_eq!(adjusted_match_opts1.proximity.unwrap().point, [0, 0], "should be 0,0");
+        assert_eq!(adjusted_match_opts1.proximity.unwrap(), [0, 0], "should be 0,0");
 
         let adjusted_match_opts2 = MATCH_OPTS_PROXIMITY.1.adjust_to_zoom(8);
         assert_eq!(
             adjusted_match_opts2.zoom, 8,
             "Adjusted MatchOpts should have target zoom as zoom"
         );
-        assert_eq!(adjusted_match_opts2.proximity.unwrap().point, [45, 101], "Should be 45, 101");
+        assert_eq!(adjusted_match_opts2.proximity.unwrap(), [45, 101], "Should be 45, 101");
 
         let same_zoom = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(4);
         assert_eq!(same_zoom, MATCH_OPTS_PROXIMITY.2, "If the zoom is the same as the original, adjusted MatchOpts should be a clone of the original");
         let zoomed_out_1z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(3);
         let proximity_out_1z = zoomed_out_1z.proximity.unwrap();
-        assert_eq!(proximity_out_1z.point, [3, 3], "4/6/6 zoomed out to zoom 3 should be 3/3/3");
-        assert_eq!(
-            proximity_out_1z.radius, 400.,
-            "The adjusted radius should be the original radius"
-        );
+        assert_eq!(proximity_out_1z, [3, 3], "4/6/6 zoomed out to zoom 3 should be 3/3/3");
         assert_eq!(zoomed_out_1z.zoom, 3, "The adjusted zoom should be the target zoom");
 
         let zoomed_out_2z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(2);
         let proximity_out_2z = zoomed_out_2z.proximity.unwrap();
-        assert_eq!(proximity_out_2z.point, [1, 1], "4/6/6 zoomed out to zoom 2 should be 2/1/1");
+        assert_eq!(proximity_out_2z, [1, 1], "4/6/6 zoomed out to zoom 2 should be 2/1/1");
 
         let zoomed_in_1z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(5);
         let proximity_in_1z = zoomed_in_1z.proximity.unwrap();
-        assert_eq!(proximity_in_1z.point, [12, 12], "4/6/6 zoomed in to zoom 5 should be 5/12/12");
+        assert_eq!(proximity_in_1z, [12, 12], "4/6/6 zoomed in to zoom 5 should be 5/12/12");
         assert_eq!(zoomed_in_1z.zoom, 5, "The adjusted zoom should be the target zoom");
 
         let zoomed_in_2z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(6);
         let proximity_in_2z = zoomed_in_2z.proximity.unwrap();
-        assert_eq!(proximity_in_2z.point, [25, 25], "4/6/6 zoomed in to zoom 6 should be 6/25/25");
+        assert_eq!(proximity_in_2z, [25, 25], "4/6/6 zoomed in to zoom 6 should be 6/25/25");
 
         let zoomed_in_3z = MATCH_OPTS_PROXIMITY.2.adjust_to_zoom(7);
         let proximity_in_3z = zoomed_in_3z.proximity.unwrap();
-        assert_eq!(proximity_in_3z.point, [51, 51], "4/6/6 zoomed in to zoom 7 should be 7/51/51");
+        assert_eq!(proximity_in_3z, [51, 51], "4/6/6 zoomed in to zoom 7 should be 7/51/51");
     }
 
     fn matchopts_bbox_generator(bbox: [u16; 4], zoom: u16) -> MatchOpts {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::collections::HashSet;
 
 use crate::gridstore::store::GridStore;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -16,7 +16,7 @@ pub use store::*;
 mod tests {
     use super::*;
     use once_cell::sync::Lazy;
-    use std::collections::BTreeMap;
+    use std::collections::{ BTreeMap, HashSet };
 
     #[test]
     fn combined_test() {
@@ -510,9 +510,9 @@ mod tests {
         builder_with_boundaries.finish().unwrap();
         builder_without_boundaries.finish().unwrap();
 
-        let reader_with_boundaries = GridStore::new(directory_with_boundaries.path()).unwrap();
+        let reader_with_boundaries = GridStore::new_with_options(directory_with_boundaries.path(), 0, 14, 0, HashSet::new(), 200.).unwrap();
         let reader_without_boundaries =
-            GridStore::new(directory_without_boundaries.path()).unwrap();
+            GridStore::new_with_options(directory_without_boundaries.path(), 0, 14, 0, HashSet::new(), 200.).unwrap();
 
         (
             reader_with_boundaries,
@@ -645,14 +645,13 @@ mod tests {
         .into_iter()
         .map(|(reader, range)| {
             let subquery = PhrasematchSubquery {
+                id: 0,
                 store: reader,
                 weight: 1.,
                 match_key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: range.0, end: range.1 },
                     lang_set: 1,
                 },
-                idx: 1,
-                zoom: 14,
                 mask: 1 << 0,
             };
             let stack = vec![subquery];

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -16,7 +16,7 @@ pub use store::*;
 mod tests {
     use super::*;
     use once_cell::sync::Lazy;
-    use std::collections::{ BTreeMap, HashSet };
+    use std::collections::{BTreeMap, HashSet};
 
     #[test]
     fn combined_test() {
@@ -193,7 +193,8 @@ mod tests {
 
         builder.finish().unwrap();
 
-        let reader = GridStore::new_with_options(directory.path(), 0, 14, 0, HashSet::new(), 1000.).unwrap();
+        let reader =
+            GridStore::new_with_options(directory.path(), 0, 14, 0, HashSet::new(), 1000.).unwrap();
 
         let search_key =
             MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
@@ -389,11 +390,7 @@ mod tests {
         let records: Vec<_> = reader
             .streaming_get_matching(
                 &search_key,
-                &MatchOpts {
-                    bbox: None,
-                    proximity: Some([26, 1]),
-                    ..MatchOpts::default()
-                },
+                &MatchOpts { bbox: None, proximity: Some([26, 1]), ..MatchOpts::default() },
                 MAX_CONTEXTS,
             )
             .unwrap()
@@ -510,9 +507,24 @@ mod tests {
         builder_with_boundaries.finish().unwrap();
         builder_without_boundaries.finish().unwrap();
 
-        let reader_with_boundaries = GridStore::new_with_options(directory_with_boundaries.path(), 0, 14, 0, HashSet::new(), 200.).unwrap();
-        let reader_without_boundaries =
-            GridStore::new_with_options(directory_without_boundaries.path(), 0, 14, 0, HashSet::new(), 200.).unwrap();
+        let reader_with_boundaries = GridStore::new_with_options(
+            directory_with_boundaries.path(),
+            0,
+            14,
+            0,
+            HashSet::new(),
+            200.,
+        )
+        .unwrap();
+        let reader_without_boundaries = GridStore::new_with_options(
+            directory_without_boundaries.path(),
+            0,
+            14,
+            0,
+            HashSet::new(),
+            200.,
+        )
+        .unwrap();
 
         (
             reader_with_boundaries,

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -193,7 +193,7 @@ mod tests {
 
         builder.finish().unwrap();
 
-        let reader = GridStore::new(directory.path()).unwrap();
+        let reader = GridStore::new_with_options(directory.path(), 0, 14, 0, HashSet::new(), 1000.).unwrap();
 
         let search_key =
             MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
@@ -391,7 +391,7 @@ mod tests {
                 &search_key,
                 &MatchOpts {
                     bbox: None,
-                    proximity: Some(Proximity { point: [26, 1], radius: 1000. }),
+                    proximity: Some([26, 1]),
                     ..MatchOpts::default()
                 },
                 MAX_CONTEXTS,
@@ -424,7 +424,7 @@ mod tests {
                 &search_key,
                 &MatchOpts {
                     bbox: Some([10, 0, 41, 2]),
-                    proximity: Some(Proximity { point: [26, 1], radius: 1000. }),
+                    proximity: Some([26, 1]),
                     ..MatchOpts::default()
                 },
                 MAX_CONTEXTS,

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -5,8 +5,6 @@ use std::cmp::Reverse;
 use std::collections::HashSet;
 use std::fmt::Debug;
 
-use crate::gridstore::builder::*;
-use crate::gridstore::common::MatchPhrase::Range;
 use crate::gridstore::common::*;
 use crate::gridstore::store::*;
 

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -12,26 +12,24 @@ use crate::gridstore::store::*;
 
 #[derive(Debug, Clone)]
 pub struct StackableNode<T: Borrow<GridStore> + Clone + Debug> {
-    pub phrasematch: Option<PhrasematchResults<T>>,
+    pub phrasematch: Option<PhrasematchSubquery<T>>,
     pub children: Vec<StackableNode<T>>,
     pub nmask: u32,
     pub bmask: HashSet<u16>,
     pub mask: u32,
     pub idx: u16,
     pub max_relev: f64,
-    pub adjusted_relev: f64,
     pub zoom: u16,
 }
 
 pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
-    phrasematch_results: &Vec<Vec<PhrasematchResults<T>>>,
-    phrasematch_result: Option<PhrasematchResults<T>>,
+    phrasematch_results: &Vec<Vec<PhrasematchSubquery<T>>>,
+    phrasematch_result: Option<PhrasematchSubquery<T>>,
     nmask: u32,
     bmask: HashSet<u16>,
     mask: u32,
     idx: u16,
     max_relev: f64,
-    adjusted_relev: f64,
     zoom: u16,
 ) -> StackableNode<T> {
     let mut node = StackableNode {
@@ -42,34 +40,32 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
         nmask: nmask,
         idx: idx,
         max_relev: max_relev,
-        adjusted_relev: adjusted_relev,
         zoom: zoom,
     };
 
     for phrasematch_per_index in phrasematch_results.iter() {
         for phrasematches in phrasematch_per_index.iter() {
             if node.phrasematch.is_some() {
-                if node.zoom > phrasematches.zoom {
+                if node.zoom > phrasematches.store.borrow().zoom {
                     continue;
-                } else if node.zoom == phrasematches.zoom {
-                    if node.idx > phrasematches.idx {
+                } else if node.zoom == phrasematches.store.borrow().zoom {
+                    if node.idx > phrasematches.store.borrow().idx {
                         continue;
                     }
                 }
             }
 
-            if (node.nmask & phrasematches.nmask) == 0
+            if (node.nmask & (1u32 << phrasematches.store.borrow().type_id)) == 0
                 && (node.mask & phrasematches.mask) == 0
-                && phrasematches.bmask.contains(&node.idx) == false
+                && phrasematches.store.borrow().non_overlapping_indexes.contains(&node.idx) == false
             {
-                let target_nmask = &phrasematches.nmask | node.nmask;
+                let target_nmask = &(1u32 << phrasematches.store.borrow().type_id) | node.nmask;
                 let target_mask = &phrasematches.mask | node.mask;
                 let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
-                let phrasematch_bmask: HashSet<u16> = phrasematches.bmask.iter().cloned().collect();
+                let phrasematch_bmask: HashSet<u16> =
+                    phrasematches.store.borrow().non_overlapping_indexes.iter().cloned().collect();
                 target_bmask.extend(&phrasematch_bmask);
                 let target_relev = 0.0 + &phrasematches.weight;
-                let target_adjusted_relev =
-                    node.adjusted_relev + (&phrasematches.weight * &phrasematches.edit_multiplier);
 
                 node.children.push(stackable(
                     &phrasematch_results,
@@ -77,10 +73,9 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
                     target_nmask,
                     target_bmask,
                     target_mask,
-                    phrasematches.idx,
+                    phrasematches.store.borrow().idx,
                     target_relev,
-                    target_adjusted_relev,
-                    phrasematches.zoom,
+                    phrasematches.store.borrow().zoom,
                 ));
             }
         }
@@ -114,55 +109,31 @@ mod test {
         builder.finish().unwrap();
         let store = GridStore::new(directory.path()).unwrap();
 
-        let a1 = PhrasematchResults {
+        let a1 = PhrasematchSubquery {
             id: 0,
             store: &store,
-            scorefactor: 0,
-            prefix: 0,
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
-            idx: 0,
-            zoom: 0,
-            nmask: 0,
             mask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
         };
 
-        let b1 = PhrasematchResults {
+        let b1 = PhrasematchSubquery {
             id: 0,
             store: &store,
-            scorefactor: 0,
-            prefix: 0,
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
-            idx: 1,
-            zoom: 1,
-            nmask: 1,
             mask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
         };
 
-        let b2 = PhrasematchResults {
+        let b2 = PhrasematchSubquery {
             id: 0,
             store: &store,
-            scorefactor: 0,
-            prefix: 0,
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
-            idx: 1,
-            zoom: 6,
-            nmask: 1,
             mask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
         };
 
         let phrasematch_results = vec![vec![a1, b1, b2]];
-        stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+        stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     }
 }

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -91,6 +91,9 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::gridstore::common::MatchPhrase::Range;
+    use crate::gridstore::builder::*;
+
     #[test]
     fn stackable_test() {
         let directory: tempfile::TempDir = tempfile::tempdir().unwrap();

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -91,8 +91,8 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::gridstore::common::MatchPhrase::Range;
     use crate::gridstore::builder::*;
+    use crate::gridstore::common::MatchPhrase::Range;
 
     #[test]
     fn stackable_test() {

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -61,7 +61,7 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
         nmask: nmask,
         idx: idx,
         max_relev: max_relev,
-        zoom: zoom
+        zoom: zoom,
     };
 
     for phrasematches in phrasematch_results.iter() {
@@ -76,28 +76,28 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
         }
 
         if (node.nmask & (1u32 << phrasematches.store.borrow().type_id)) == 0
-                && (node.mask & phrasematches.mask) == 0
-                && phrasematches.store.borrow().non_overlapping_indexes.contains(&node.idx) == false
-            {
-                let target_nmask = &(1u32 << phrasematches.store.borrow().type_id) | node.nmask;
-                let target_mask = &phrasematches.mask | node.mask;
-                let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
-                let phrasematch_bmask: HashSet<u16> =
-                    phrasematches.store.borrow().non_overlapping_indexes.iter().cloned().collect();
-                target_bmask.extend(&phrasematch_bmask);
-                let target_relev = 0.0 + &phrasematches.weight;
+            && (node.mask & phrasematches.mask) == 0
+            && phrasematches.store.borrow().non_overlapping_indexes.contains(&node.idx) == false
+        {
+            let target_nmask = &(1u32 << phrasematches.store.borrow().type_id) | node.nmask;
+            let target_mask = &phrasematches.mask | node.mask;
+            let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
+            let phrasematch_bmask: HashSet<u16> =
+                phrasematches.store.borrow().non_overlapping_indexes.iter().cloned().collect();
+            target_bmask.extend(&phrasematch_bmask);
+            let target_relev = 0.0 + &phrasematches.weight;
 
-                node.children.push(stackable(
-                    &phrasematch_results,
-                    Some(phrasematches.clone()),
-                    target_nmask,
-                    target_bmask,
-                    target_mask,
-                    phrasematches.store.borrow().idx,
-                    target_relev,
-                    phrasematches.store.borrow().zoom,
-                ));
-            }
+            node.children.push(stackable(
+                &phrasematch_results,
+                Some(phrasematches.clone()),
+                target_nmask,
+                target_bmask,
+                target_mask,
+                phrasematches.store.borrow().idx,
+                target_relev,
+                phrasematches.store.borrow().zoom,
+            ));
+        }
     }
 
     node.children.sort_by_key(|node| Reverse(OrderedFloat(node.max_relev)));
@@ -129,8 +129,10 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store1 = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
-        let store2 = GridStore::new_with_options(directory.path(), 2, 14, 2, HashSet::new(), 200.).unwrap();
+        let store1 =
+            GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+        let store2 =
+            GridStore::new_with_options(directory.path(), 2, 14, 2, HashSet::new(), 200.).unwrap();
 
         let a1 = PhrasematchSubquery {
             id: 0,

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -78,6 +78,7 @@ fn decode_matching_value<T: AsRef<[u8]>>(
     value: T,
     match_opts: &MatchOpts,
     matches_language: bool,
+    coalesce_radius: f64,
 ) -> impl Iterator<Item = MatchEntry> {
     let match_opts = match_opts.clone();
 
@@ -129,14 +130,14 @@ fn decode_matching_value<T: AsRef<[u8]>>(
                             }
                         }
                         MatchOpts { bbox: None, proximity: Some(prox_pt), .. } => {
-                            match spatial::proximity(coords_vec, prox_pt.point) {
+                            match spatial::proximity(coords_vec, *prox_pt) {
                                 Some(v) => Some(Box::new(v)
                                     as Box<dyn Iterator<Item = gridstore_format::Coord>>),
                                 None => None,
                             }
                         }
                         MatchOpts { bbox: Some(bbox), proximity: Some(prox_pt), .. } => {
-                            match spatial::bbox_proximity_filter(coords_vec, *bbox, prox_pt.point) {
+                            match spatial::bbox_proximity_filter(coords_vec, *bbox, *prox_pt) {
                                 Some(v) => Some(Box::new(v)
                                     as Box<dyn Iterator<Item = gridstore_format::Coord>>),
                                 None => None,
@@ -155,13 +156,13 @@ fn decode_matching_value<T: AsRef<[u8]>>(
                     let (distance, within_radius, scoredist) = match &match_opts {
                         MatchOpts { proximity: Some(prox_pt), zoom, .. } => {
                             let distance =
-                                spatial::tile_dist(prox_pt.point[0], prox_pt.point[1], x, y);
+                                spatial::tile_dist(prox_pt[0], prox_pt[1], x, y);
                             (
                                 distance,
                                 // The proximity radius calculation is also done in scoredist
                                 // There could be an opportunity to optimize by doing it once
-                                distance <= spatial::proximity_radius(*zoom, prox_pt.radius),
-                                spatial::scoredist(*zoom, distance, score, prox_pt.radius),
+                                distance <= spatial::proximity_radius(*zoom, coalesce_radius),
+                                spatial::scoredist(*zoom, distance, score, coalesce_radius),
                             )
                         }
                         _ => (0f64, false, score as f64),
@@ -341,7 +342,7 @@ impl GridStore {
 
         for (key, value) in db_iter {
             let matches_language = match_key.matches_language(&key).unwrap();
-            let mut entry_iter = decode_matching_value(value, &match_opts, matches_language);
+            let mut entry_iter = decode_matching_value(value, &match_opts, matches_language, self.coalesce_radius);
             if let Some(next_entry) = entry_iter.next() {
                 let queue_element = QueueElement { next_entry, entry_iter };
                 if pri_queue.len() >= max_values {

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -20,6 +20,12 @@ pub struct GridStore {
     db: DB,
     bin_boundaries: HashSet<u32>,
     pub path: PathBuf,
+    // options:
+    pub idx: u16,
+    pub zoom: u16,
+    pub type_id: u16,
+    pub non_overlapping_indexes: HashSet<u16>, // the field formerly known as bmask
+    pub coalesce_radius: f64,
 }
 
 #[inline]
@@ -245,6 +251,17 @@ impl<T: Iterator<Item = MatchEntry>> Eq for QueueElement<T> {}
 
 impl GridStore {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        GridStore::new_with_options(path, 0, 6, 0, HashSet::new(), 0.0)
+    }
+
+    pub fn new_with_options<P: AsRef<Path>>(
+        path: P,
+        idx: u16,
+        zoom: u16,
+        type_id: u16,
+        non_overlapping_indexes: HashSet<u16>,
+        coalesce_radius: f64,
+    ) -> Result<Self, Error> {
         let path = path.as_ref().to_owned();
         let mut opts = Options::default();
         opts.set_read_only(true);
@@ -268,7 +285,16 @@ impl GridStore {
             None => HashSet::new(),
         };
 
-        Ok(GridStore { db, path, bin_boundaries })
+        Ok(GridStore {
+            db,
+            path,
+            bin_boundaries,
+            idx,
+            zoom,
+            type_id,
+            non_overlapping_indexes,
+            coalesce_radius,
+        })
     }
 
     #[inline(never)]

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -155,8 +155,7 @@ fn decode_matching_value<T: AsRef<[u8]>>(
 
                     let (distance, within_radius, scoredist) = match &match_opts {
                         MatchOpts { proximity: Some(prox_pt), zoom, .. } => {
-                            let distance =
-                                spatial::tile_dist(prox_pt[0], prox_pt[1], x, y);
+                            let distance = spatial::tile_dist(prox_pt[0], prox_pt[1], x, y);
                             (
                                 distance,
                                 // The proximity radius calculation is also done in scoredist
@@ -342,7 +341,8 @@ impl GridStore {
 
         for (key, value) in db_iter {
             let matches_language = match_key.matches_language(&key).unwrap();
-            let mut entry_iter = decode_matching_value(value, &match_opts, matches_language, self.coalesce_radius);
+            let mut entry_iter =
+                decode_matching_value(value, &match_opts, matches_language, self.coalesce_radius);
             if let Some(next_entry) = entry_iter.next() {
                 let queue_element = QueueElement { next_entry, entry_iter };
                 if pri_queue.len() >= max_values {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -11,7 +11,7 @@ use rusoto_core::Region;
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use serde::{Deserialize, Serialize};
 
-use std::collections::{ HashMap, HashSet };
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufWriter, Read, Write};
@@ -66,7 +66,15 @@ pub fn create_store(
         builder.insert(&build_block.grid_key, build_block.entries).expect("Unable to insert");
     }
     builder.finish().unwrap();
-    GridStore::new_with_options(directory.path(), idx, zoom, type_id, non_overlapping_indexes, coalesce_radius).unwrap()
+    GridStore::new_with_options(
+        directory.path(),
+        idx,
+        zoom,
+        type_id,
+        non_overlapping_indexes,
+        coalesce_radius,
+    )
+    .unwrap()
 }
 
 // Gets the absolute path for a path relative to the carmen-core dir

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -223,7 +223,7 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
         ]
     );
     builder.finish();
-    const reader = new addon.GridStore(tmpDir.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
+    const reader = new addon.GridStore(tmpDir.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
 
     const valid_stack = [{
         store: reader,
@@ -271,7 +271,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder1.finish();
-    const reader1 = new addon.GridStore(tmpDir1.name, { idx: 0, zoom: 1, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
+    const reader1 = new addon.GridStore(tmpDir1.name, { idx: 0, zoom: 1, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
 
     const tmpDir2 = tmp.dirSync();
     const builder2 = new addon.GridStoreBuilder(tmpDir2.name);
@@ -282,7 +282,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder2.finish();
-    const reader2 = new addon.GridStore(tmpDir2.name, { idx: 1, zoom: 2, non_overlapping_indexes: [], type_id: 1, coalesce_radius: 200 });
+    const reader2 = new addon.GridStore(tmpDir2.name, { idx: 1, zoom: 2, non_overlapping_indexes: Array.from(new Set()), type_id: 1, coalesce_radius: 200 });
 
     const valid_coalesce_multi = [{
         store: reader1,
@@ -413,8 +413,8 @@ tape('Bin boundaries', (t) => {
     builderWithBoundaries.finish();
     builderWithoutBoundaries.finish();
 
-    const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
-    const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
+    const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
+    const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
 
     const findRange = (prefix) => {
         let start = null,
@@ -472,7 +472,7 @@ tape('Deserialize phrasematch results', (t) => {
         ]
     );
     builder.finish();
-    const store = new addon.GridStore(tmpDir.name, { idx: 0, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
+    const store = new addon.GridStore(tmpDir.name, { idx: 0, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
     let phrasematchResults = [
         new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1)
     ];

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -474,14 +474,7 @@ tape('Deserialize phrasematch results', (t) => {
     builder.finish();
     const store = new addon.GridStore(tmpDir.name, { idx: 0, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
     let phrasematchResults = [
-        {
-            'phrasematches': [
-                new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1)
-            ],
-            idx: 0,
-            nmask: 14,
-            bmask: [0]
-        }
+        new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1)
     ];
     addon.stackable(phrasematchResults);
     t.end();

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -223,7 +223,7 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
         ]
     );
     builder.finish();
-    const reader = new addon.GridStore(tmpDir.name);
+    const reader = new addon.GridStore(tmpDir.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
 
     const valid_stack = [{
         store: reader,
@@ -240,6 +240,7 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
         idx: 1,
         zoom: 14,
         mask: 1 << 0,
+        id: 0
     }];
 
     addon.coalesce(valid_stack, { zoom: 14 }, (err, res) => {
@@ -270,7 +271,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder1.finish();
-    const reader1 = new addon.GridStore(tmpDir1.name);
+    const reader1 = new addon.GridStore(tmpDir1.name, { idx: 0, zoom: 1, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
 
     const tmpDir2 = tmp.dirSync();
     const builder2 = new addon.GridStoreBuilder(tmpDir2.name);
@@ -281,7 +282,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder2.finish();
-    const reader2 = new addon.GridStore(tmpDir2.name);
+    const reader2 = new addon.GridStore(tmpDir2.name, { idx: 1, zoom: 2, non_overlapping_indexes: [], type_id: 1, coalesce_radius: 200 });
 
     const valid_coalesce_multi = [{
         store: reader1,
@@ -298,6 +299,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         idx: 0,
         zoom: 1,
         mask: 1 << 1,
+        id: 0
     },{
         store: reader2,
         weight: 0.5,
@@ -313,6 +315,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         idx: 1,
         zoom: 2,
         mask: 1 << 0,
+        id: 1
     }];
     addon.coalesce(valid_coalesce_multi, { zoom: 2 }, (err, res) => {
         t.deepEqual(res[0].entries[0].grid_entry, { relev: 0.5, score: 3, x: 2, y: 2, id: 2, source_phrase_hash: 0 }, '1st result highest score from the higher zoom index');
@@ -347,6 +350,7 @@ tape('lang_set >= 128', (t) => {
         idx: 1,
         zoom: 14,
         mask: 1 << 0,
+        id: 0
     }];
 
     addon.coalesce(lang_set_stack, { zoom: 14 }, (err, res) => {
@@ -409,8 +413,8 @@ tape('Bin boundaries', (t) => {
     builderWithBoundaries.finish();
     builderWithoutBoundaries.finish();
 
-    const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name);
-    const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name);
+    const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
+    const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
 
     const findRange = (prefix) => {
         let start = null,
@@ -442,6 +446,7 @@ tape('Bin boundaries', (t) => {
             idx: 1,
             zoom: 14,
             mask: 1,
+            id: 0
         };
         let stack = [subquery];
         let match_opts = {
@@ -467,7 +472,7 @@ tape('Deserialize phrasematch results', (t) => {
         ]
     );
     builder.finish();
-    const store = new addon.GridStore(tmpDir.name);
+    const store = new addon.GridStore(tmpDir.name, { idx: 0, zoom: 14, non_overlapping_indexes: [], type_id: 0, coalesce_radius: 200 });
     let phrasematchResults = [
         {
             'phrasematches': [

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -35,7 +35,7 @@ fn coalesce_single_test_proximity_quadrants() {
     println!("Coalesce single - NE proximity");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [110, 115], radius: 200. }), // NE proximity point
+        proximity: Some([110, 115]), // NE proximity point
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -52,7 +52,7 @@ fn coalesce_single_test_proximity_quadrants() {
     println!("Coalesce single - SE proximity");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [110, 85], radius: 200. }), // SE proximity point
+        proximity: Some([110, 85]), // SE proximity point
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -69,7 +69,7 @@ fn coalesce_single_test_proximity_quadrants() {
     println!("Coalesce single - SW proximity");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [90, 85], radius: 200. }), // SW proximity point
+        proximity: Some([90, 85]), // SW proximity point
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -86,7 +86,7 @@ fn coalesce_single_test_proximity_quadrants() {
     println!("Coalesce single - NW proximity");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [90, 115], radius: 200. }), // NW proximity point
+        proximity: Some([90, 115]), // NW proximity point
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -129,7 +129,7 @@ fn coalesce_single_test_proximity_basic() {
     let stack = vec![subquery];
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [2, 2], radius: 400. }),
+        proximity: Some([2, 2]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -169,7 +169,7 @@ fn coalesce_single_test_language_penalty() {
     builder.insert(&key, entries).expect("Unable to insert record");
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 1.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -180,7 +180,7 @@ fn coalesce_single_test_language_penalty() {
     let stack = vec![subquery.clone()];
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [2, 2], radius: 1. }),
+        proximity: Some([2, 2]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -257,7 +257,7 @@ fn coalesce_multi_test_language_penalty() {
 
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [2, 2], radius: 1. }),
+        proximity: Some([2, 2]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -298,7 +298,7 @@ fn coalesce_single_test() {
             GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
             GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }], 1, 6, 0, HashSet::new(), 200.);
+    }], 1, 6, 0, HashSet::new(), 40.);
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -368,7 +368,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with proximity");
     let match_opts = MatchOpts {
         zoom: 6,
-        proximity: Some(Proximity { point: [3, 3], radius: 40. }),
+        proximity: Some([3, 3]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -498,7 +498,7 @@ fn coalesce_single_test() {
     let match_opts = MatchOpts {
         zoom: 6,
         bbox: Some([1, 1, 1, 1]),
-        proximity: Some(Proximity { point: [1, 1], radius: 40. }),
+        proximity: Some([1, 1]),
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
@@ -680,7 +680,7 @@ fn coalesce_multi_test() {
             // TODO: this isn't a real tile at zoom 1. Maybe pick more realistic test case?
             GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }], 0, 1, 0, HashSet::new(), 200.);
+    }], 0, 1, 0, HashSet::new(), 40.);
 
     let store2 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 2, lang_set: 1 },
@@ -689,7 +689,7 @@ fn coalesce_multi_test() {
             GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 3, source_phrase_hash: 0 },
             GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }], 1, 2, 1, HashSet::new(), 200.);
+    }], 1, 2, 1, HashSet::new(), 40.);
 
     let stack = vec![
         PhrasematchSubquery {
@@ -816,7 +816,7 @@ fn coalesce_multi_test() {
     println!("Coalesce multi - with proximity");
     let match_opts = MatchOpts {
         zoom: 2,
-        proximity: Some(Proximity { point: [3, 3], radius: 40. }),
+        proximity: Some([3, 3]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -1143,7 +1143,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity very close to one grid");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [4601, 6200], radius: 40. }),
+        proximity: Some([4601, 6200]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
@@ -1162,7 +1162,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity less close to one grid");
     let match_opts = MatchOpts {
         zoom: 14,
-        proximity: Some(Proximity { point: [4610, 6200], radius: 40. }),
+        proximity: Some([4610, 6200]),
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -22,7 +22,8 @@ fn coalesce_single_test_proximity_quadrants() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -118,7 +119,8 @@ fn coalesce_single_test_proximity_basic() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -127,11 +129,7 @@ fn coalesce_single_test_proximity_basic() {
         mask: 1 << 0,
     };
     let stack = vec![subquery];
-    let match_opts = MatchOpts {
-        zoom: 14,
-        proximity: Some([2, 2]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -169,7 +167,8 @@ fn coalesce_single_test_language_penalty() {
     builder.insert(&key, entries).expect("Unable to insert record");
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 1.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 1.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -178,11 +177,7 @@ fn coalesce_single_test_language_penalty() {
         mask: 1 << 0,
     };
     let stack = vec![subquery.clone()];
-    let match_opts = MatchOpts {
-        zoom: 14,
-        proximity: Some([2, 2]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -213,22 +208,36 @@ fn coalesce_single_test_language_penalty() {
 #[test]
 fn coalesce_multi_test_language_penalty() {
     // Add more specific layer into a store
-    let store1 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: 1 },
-        entries: vec![
-            GridEntry { id: 1, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
-            GridEntry { id: 2, x: 12800, y: 12800, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 1, 14, 0, HashSet::new(), 200.);
+    let store1 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: 1 },
+            entries: vec![
+                GridEntry { id: 1, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
+                GridEntry { id: 2, x: 12800, y: 12800, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        1,
+        14,
+        0,
+        HashSet::new(),
+        200.,
+    );
 
     // Add less specific layer into a store
-    let store2 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 2, lang_set: 1 },
-        entries: vec![
-            GridEntry { id: 3, x: 0, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
-            GridEntry { id: 4, x: 50, y: 50, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 2, 6, 1, HashSet::new(), 200.);
+    let store2 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 2, lang_set: 1 },
+            entries: vec![
+                GridEntry { id: 3, x: 0, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
+                GridEntry { id: 4, x: 50, y: 50, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        2,
+        6,
+        1,
+        HashSet::new(),
+        200.,
+    );
 
     // Subqueries with a different language set
     println!("Coalesce multi - Subqueries with different language set from grids, with proximity");
@@ -255,11 +264,7 @@ fn coalesce_multi_test_language_penalty() {
         },
     ];
 
-    let match_opts = MatchOpts {
-        zoom: 14,
-        proximity: Some([2, 2]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -291,14 +296,21 @@ fn coalesce_multi_test_language_penalty() {
 
 #[test]
 fn coalesce_single_test() {
-    let store = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: 1 },
-        entries: vec![
-            GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 3, source_phrase_hash: 0 },
-            GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
-            GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 1, 6, 0, HashSet::new(), 40.);
+    let store = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: 1 },
+            entries: vec![
+                GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 3, source_phrase_hash: 0 },
+                GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
+                GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        1,
+        6,
+        0,
+        HashSet::new(),
+        40.,
+    );
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
@@ -366,11 +378,7 @@ fn coalesce_single_test() {
     }
     // Test opts with proximity
     println!("Coalsece single - with proximity");
-    let match_opts = MatchOpts {
-        zoom: 6,
-        proximity: Some([3, 3]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 6, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -495,11 +503,7 @@ fn coalesce_single_test() {
 
     // Test with bbox and proximity
     println!("Coalesce single - with bbox and proximity");
-    let match_opts = MatchOpts {
-        zoom: 6,
-        bbox: Some([1, 1, 1, 1]),
-        proximity: Some([1, 1]),
-    };
+    let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), proximity: Some([1, 1]) };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -548,7 +552,8 @@ fn coalesce_single_languages_test() {
     }
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 1, 6, 1, HashSet::new(), 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 1, 6, 1, HashSet::new(), 200.).unwrap();
     // Test query with all languages
     println!("Coalesce single - all languages");
     let subquery = PhrasematchSubquery {
@@ -673,23 +678,37 @@ fn coalesce_single_languages_test() {
 #[test]
 fn coalesce_multi_test() {
     // Add more specific layer into a store
-    let store1 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: 1 },
-        entries: vec![
-            GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
-            // TODO: this isn't a real tile at zoom 1. Maybe pick more realistic test case?
-            GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 0, 1, 0, HashSet::new(), 40.);
+    let store1 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: 1 },
+            entries: vec![
+                GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
+                // TODO: this isn't a real tile at zoom 1. Maybe pick more realistic test case?
+                GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        0,
+        1,
+        0,
+        HashSet::new(),
+        40.,
+    );
 
-    let store2 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 2, lang_set: 1 },
-        entries: vec![
-            GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 3, source_phrase_hash: 0 },
-            GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 3, source_phrase_hash: 0 },
-            GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 1, 2, 1, HashSet::new(), 40.);
+    let store2 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 2, lang_set: 1 },
+            entries: vec![
+                GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 3, source_phrase_hash: 0 },
+                GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 3, source_phrase_hash: 0 },
+                GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        1,
+        2,
+        1,
+        HashSet::new(),
+        40.,
+    );
 
     let stack = vec![
         PhrasematchSubquery {
@@ -814,11 +833,7 @@ fn coalesce_multi_test() {
 
     // Test coalesce multi with proximity
     println!("Coalesce multi - with proximity");
-    let match_opts = MatchOpts {
-        zoom: 2,
-        proximity: Some([3, 3]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 2, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -916,38 +931,59 @@ fn coalesce_multi_test() {
 #[test]
 fn coalesce_multi_languages_test() {
     // Store 1 with grids in all languages
-    let store1 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: ALL_LANGUAGES },
-        entries: vec![GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 }],
-    }], 0, 1, 0, HashSet::new(), 200.);
+    let store1 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: ALL_LANGUAGES },
+            entries: vec![GridEntry {
+                id: 1,
+                x: 1,
+                y: 1,
+                relev: 1.,
+                score: 1,
+                source_phrase_hash: 0,
+            }],
+        }],
+        0,
+        1,
+        0,
+        HashSet::new(),
+        200.,
+    );
 
     // Store 2 with grids in multiple language sets
-    let store2 = create_store(vec![
-        // Insert grid with lang_set 1
-        StoreEntryBuildingBlock {
-            grid_key: GridKey { phrase_id: 2, lang_set: langarray_to_langfield(&[1]) },
-            entries: vec![GridEntry {
-                id: 2,
-                x: 1,
-                y: 1,
-                relev: 1.,
-                score: 1,
-                source_phrase_hash: 0,
-            }],
-        },
-        // Insert grid with lang_set 0
-        StoreEntryBuildingBlock {
-            grid_key: GridKey { phrase_id: 2, lang_set: langarray_to_langfield(&[0]) },
-            entries: vec![GridEntry {
-                id: 3,
-                x: 1,
-                y: 1,
-                relev: 1.,
-                score: 1,
-                source_phrase_hash: 0,
-            }],
-        },
-    ], 1, 1, 1, HashSet::new(), 200.);
+    let store2 = create_store(
+        vec![
+            // Insert grid with lang_set 1
+            StoreEntryBuildingBlock {
+                grid_key: GridKey { phrase_id: 2, lang_set: langarray_to_langfield(&[1]) },
+                entries: vec![GridEntry {
+                    id: 2,
+                    x: 1,
+                    y: 1,
+                    relev: 1.,
+                    score: 1,
+                    source_phrase_hash: 0,
+                }],
+            },
+            // Insert grid with lang_set 0
+            StoreEntryBuildingBlock {
+                grid_key: GridKey { phrase_id: 2, lang_set: langarray_to_langfield(&[0]) },
+                entries: vec![GridEntry {
+                    id: 3,
+                    x: 1,
+                    y: 1,
+                    relev: 1.,
+                    score: 1,
+                    source_phrase_hash: 0,
+                }],
+            },
+        ],
+        1,
+        1,
+        1,
+        HashSet::new(),
+        200.,
+    );
 
     // Test ALL LANGUAGES
     println!("Coalesce multi - all languages");
@@ -1103,19 +1139,40 @@ fn coalesce_multi_languages_test() {
 #[test]
 fn coalesce_multi_scoredist() {
     // Add more specific layer into a store
-    let store1 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: 0 },
-        entries: vec![GridEntry { id: 1, x: 0, y: 0, relev: 1., score: 1, source_phrase_hash: 0 }],
-    }], 0, 0, 0, HashSet::new(), 200.);
+    let store1 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: 0 },
+            entries: vec![GridEntry {
+                id: 1,
+                x: 0,
+                y: 0,
+                relev: 1.,
+                score: 1,
+                source_phrase_hash: 0,
+            }],
+        }],
+        0,
+        0,
+        0,
+        HashSet::new(),
+        200.,
+    );
 
     // Add less specific layer into a store
-    let store2 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 2, lang_set: 0 },
-        entries: vec![
-            GridEntry { id: 2, x: 4800, y: 6200, relev: 1., score: 7, source_phrase_hash: 0 },
-            GridEntry { id: 3, x: 4600, y: 6200, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 1, 14, 1, HashSet::new(), 200.);
+    let store2 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 2, lang_set: 0 },
+            entries: vec![
+                GridEntry { id: 2, x: 4800, y: 6200, relev: 1., score: 7, source_phrase_hash: 0 },
+                GridEntry { id: 3, x: 4600, y: 6200, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        1,
+        14,
+        1,
+        HashSet::new(),
+        200.,
+    );
 
     let stack = vec![
         PhrasematchSubquery {
@@ -1141,11 +1198,7 @@ fn coalesce_multi_scoredist() {
     ];
     // Closer proximity to one grid
     println!("Coalesce multi - proximity very close to one grid");
-    let match_opts = MatchOpts {
-        zoom: 14,
-        proximity: Some([4601, 6200]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([4601, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -1160,11 +1213,7 @@ fn coalesce_multi_scoredist() {
 
     // Proximity is still close to same grid, but less close
     println!("Coalesce multi - proximity less close to one grid");
-    let match_opts = MatchOpts {
-        zoom: 14,
-        proximity: Some([4610, 6200]),
-        ..MatchOpts::default()
-    };
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([4610, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
     let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
@@ -1181,28 +1230,49 @@ fn coalesce_multi_scoredist() {
 // TODO: language tests
 #[test]
 fn coalesce_multi_test_bbox() {
-    let store1 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 1, lang_set: ALL_LANGUAGES },
-        entries: vec![
-            GridEntry { id: 1, x: 0, y: 0, relev: 0.8, score: 1, source_phrase_hash: 0 },
-            GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 0, 1, 0, HashSet::new(), 200.);
-    let store2 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 2, lang_set: ALL_LANGUAGES },
-        entries: vec![
-            GridEntry { id: 3, x: 3, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
-            GridEntry { id: 4, x: 0, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 1, 2, 1, HashSet::new(), 200.);
+    let store1 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 1, lang_set: ALL_LANGUAGES },
+            entries: vec![
+                GridEntry { id: 1, x: 0, y: 0, relev: 0.8, score: 1, source_phrase_hash: 0 },
+                GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        0,
+        1,
+        0,
+        HashSet::new(),
+        200.,
+    );
+    let store2 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 2, lang_set: ALL_LANGUAGES },
+            entries: vec![
+                GridEntry { id: 3, x: 3, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
+                GridEntry { id: 4, x: 0, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        1,
+        2,
+        1,
+        HashSet::new(),
+        200.,
+    );
 
-    let store3 = create_store(vec![StoreEntryBuildingBlock {
-        grid_key: GridKey { phrase_id: 3, lang_set: ALL_LANGUAGES },
-        entries: vec![
-            GridEntry { id: 5, x: 21, y: 7, relev: 1., score: 1, source_phrase_hash: 0 },
-            GridEntry { id: 6, x: 21, y: 18, relev: 1., score: 1, source_phrase_hash: 0 },
-        ],
-    }], 2, 5, 2, HashSet::new(), 200.);
+    let store3 = create_store(
+        vec![StoreEntryBuildingBlock {
+            grid_key: GridKey { phrase_id: 3, lang_set: ALL_LANGUAGES },
+            entries: vec![
+                GridEntry { id: 5, x: 21, y: 7, relev: 1., score: 1, source_phrase_hash: 0 },
+                GridEntry { id: 6, x: 21, y: 18, relev: 1., score: 1, source_phrase_hash: 0 },
+            ],
+        }],
+        2,
+        5,
+        2,
+        HashSet::new(),
+        200.,
+    );
 
     let stack = vec![
         PhrasematchSubquery {

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -22,20 +22,12 @@ fn coalesce_single_test_proximity_quadrants() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchResults {
+    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
-        idx: 1,
-        zoom: 14,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
@@ -47,7 +39,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -64,7 +56,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -81,7 +73,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -98,7 +90,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -126,20 +118,12 @@ fn coalesce_single_test_proximity_basic() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchResults {
+    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
-        idx: 1,
-        zoom: 14,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
@@ -149,7 +133,7 @@ fn coalesce_single_test_proximity_basic() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -185,20 +169,12 @@ fn coalesce_single_test_language_penalty() {
     builder.insert(&key, entries).expect("Unable to insert record");
     builder.finish().unwrap();
 
-    let store = GridStore::new(directory.path()).unwrap();
-    let subquery = PhrasematchResults {
+    let store = GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 },
-        idx: 1,
-        zoom: 14,
         mask: 1 << 0,
     };
     let stack = vec![subquery.clone()];
@@ -208,7 +184,7 @@ fn coalesce_single_test_language_penalty() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -223,7 +199,7 @@ fn coalesce_single_test_language_penalty() {
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -243,7 +219,7 @@ fn coalesce_multi_test_language_penalty() {
             GridEntry { id: 1, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
             GridEntry { id: 2, x: 12800, y: 12800, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 1, 14, 0, HashSet::new(), 200.);
 
     // Add less specific layer into a store
     let store2 = create_store(vec![StoreEntryBuildingBlock {
@@ -252,45 +228,29 @@ fn coalesce_multi_test_language_penalty() {
             GridEntry { id: 3, x: 0, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
             GridEntry { id: 4, x: 50, y: 50, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 2, 6, 1, HashSet::new(), 200.);
 
     // Subqueries with a different language set
     println!("Coalesce multi - Subqueries with different language set from grids, with proximity");
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 2,
             },
-            idx: 1,
-            zoom: 14,
             mask: 1 << 0,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 2,
             },
-            idx: 2,
-            zoom: 6,
             mask: 1 << 1,
         },
     ];
@@ -301,7 +261,7 @@ fn coalesce_multi_test_language_penalty() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -318,7 +278,7 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -338,20 +298,12 @@ fn coalesce_single_test() {
             GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
             GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
-    let subquery = PhrasematchResults {
+    }], 1, 6, 0, HashSet::new(), 200.);
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
-        idx: 1,
-        zoom: 6,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
@@ -360,7 +312,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -420,7 +372,7 @@ fn coalesce_single_test() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -510,7 +462,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -549,7 +501,7 @@ fn coalesce_single_test() {
         proximity: Some(Proximity { point: [1, 1], radius: 40. }),
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -596,31 +548,23 @@ fn coalesce_single_languages_test() {
     }
     builder.finish().unwrap();
 
-    let store = GridStore::new(directory.path()).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 1, 6, 1, HashSet::new(), 200.).unwrap();
     // Test query with all languages
     println!("Coalesce single - all languages");
-    let subquery = PhrasematchResults {
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
             lang_set: ALL_LANGUAGES,
         },
-        idx: 0,
-        zoom: 6,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -647,28 +591,20 @@ fn coalesce_single_languages_test() {
 
     // Test lanuage 0
     println!("Coalesce single - language 0, language matching 2 grids");
-    let subquery = PhrasematchResults {
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
             lang_set: langarray_to_langfield(&[0]),
         },
-        idx: 0,
-        zoom: 6,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -695,28 +631,20 @@ fn coalesce_single_languages_test() {
 
     println!("Coalesce single - language 3, language matching no grids");
 
-    let subquery = PhrasematchResults {
+    let subquery = PhrasematchSubquery {
         id: 0,
-        scorefactor: 0,
-        prefix: 0,
-        nmask: 1,
-        bmask: HashSet::new(),
-        edit_multiplier: 1.0,
-        subquery_edit_distance: 0,
         store: &store,
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
             lang_set: langarray_to_langfield(&[3]),
         },
-        idx: 0,
-        zoom: 6,
         mask: 1 << 0,
     };
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -752,7 +680,7 @@ fn coalesce_multi_test() {
             // TODO: this isn't a real tile at zoom 1. Maybe pick more realistic test case?
             GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 0, 1, 0, HashSet::new(), 200.);
 
     let store2 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 2, lang_set: 1 },
@@ -761,43 +689,27 @@ fn coalesce_multi_test() {
             GridEntry { id: 2, x: 2, y: 2, relev: 1., score: 3, source_phrase_hash: 0 },
             GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 1, 2, 1, HashSet::new(), 200.);
 
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 1,
             },
-            idx: 0,
-            zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 1,
             },
-            idx: 1,
-            zoom: 2,
             mask: 1 << 0,
         },
     ];
@@ -806,7 +718,7 @@ fn coalesce_multi_test() {
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
@@ -908,7 +820,7 @@ fn coalesce_multi_test() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
@@ -1007,7 +919,7 @@ fn coalesce_multi_languages_test() {
     let store1 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 1, lang_set: ALL_LANGUAGES },
         entries: vec![GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 }],
-    }]);
+    }], 0, 1, 0, HashSet::new(), 200.);
 
     // Store 2 with grids in multiple language sets
     let store2 = create_store(vec![
@@ -1035,52 +947,35 @@ fn coalesce_multi_languages_test() {
                 source_phrase_hash: 0,
             }],
         },
-    ]);
+    ], 1, 1, 1, HashSet::new(), 200.);
 
     // Test ALL LANGUAGES
     println!("Coalesce multi - all languages");
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 0,
-            zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 1,
-            // TODO: when would these have the same zoom?
-            zoom: 1,
             mask: 1 << 0,
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1107,47 +1002,30 @@ fn coalesce_multi_languages_test() {
     // Test language 0
     println!("Coalesce multi - language 0");
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 0,
-            zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: langarray_to_langfield(&[0]),
             },
-            idx: 1,
-            // TODO: when would these have the same zoom?
-            zoom: 1,
             mask: 1 << 0,
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1174,47 +1052,30 @@ fn coalesce_multi_languages_test() {
     // Test language 3
     println!("Coalsece multi - language 3");
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 0,
-            zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: langarray_to_langfield(&[3]),
             },
-            idx: 1,
-            // TODO: when would these have the same zoom?
-            zoom: 1,
             mask: 1 << 0,
         },
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1245,7 +1106,7 @@ fn coalesce_multi_scoredist() {
     let store1 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 1, lang_set: 0 },
         entries: vec![GridEntry { id: 1, x: 0, y: 0, relev: 1., score: 1, source_phrase_hash: 0 }],
-    }]);
+    }], 0, 0, 0, HashSet::new(), 200.);
 
     // Add less specific layer into a store
     let store2 = create_store(vec![StoreEntryBuildingBlock {
@@ -1254,43 +1115,27 @@ fn coalesce_multi_scoredist() {
             GridEntry { id: 2, x: 4800, y: 6200, relev: 1., score: 7, source_phrase_hash: 0 },
             GridEntry { id: 3, x: 4600, y: 6200, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 1, 14, 1, HashSet::new(), 200.);
 
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 0,
             },
-            idx: 0,
-            zoom: 0,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: 0,
             },
-            idx: 1,
-            zoom: 14,
             mask: 1 << 0,
         },
     ];
@@ -1302,7 +1147,7 @@ fn coalesce_multi_scoredist() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
@@ -1321,7 +1166,7 @@ fn coalesce_multi_scoredist() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
@@ -1342,14 +1187,14 @@ fn coalesce_multi_test_bbox() {
             GridEntry { id: 1, x: 0, y: 0, relev: 0.8, score: 1, source_phrase_hash: 0 },
             GridEntry { id: 2, x: 1, y: 1, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 0, 1, 0, HashSet::new(), 200.);
     let store2 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 2, lang_set: ALL_LANGUAGES },
         entries: vec![
             GridEntry { id: 3, x: 3, y: 0, relev: 1., score: 1, source_phrase_hash: 0 },
             GridEntry { id: 4, x: 0, y: 3, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 1, 2, 1, HashSet::new(), 200.);
 
     let store3 = create_store(vec![StoreEntryBuildingBlock {
         grid_key: GridKey { phrase_id: 3, lang_set: ALL_LANGUAGES },
@@ -1357,43 +1202,27 @@ fn coalesce_multi_test_bbox() {
             GridEntry { id: 5, x: 21, y: 7, relev: 1., score: 1, source_phrase_hash: 0 },
             GridEntry { id: 6, x: 21, y: 18, relev: 1., score: 1, source_phrase_hash: 0 },
         ],
-    }]);
+    }], 2, 5, 2, HashSet::new(), 200.);
 
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store1,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 0,
-            zoom: 1,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 1,
-            zoom: 2,
             mask: 1 << 0,
         },
     ];
@@ -1401,7 +1230,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
@@ -1419,7 +1248,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
@@ -1438,7 +1267,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
@@ -1456,46 +1285,30 @@ fn coalesce_multi_test_bbox() {
     // Test bbox at lower zoom than either of the expected results
     println!("Coalesce multi - bbox at lower zoom than either of the expected results");
     let stack = vec![
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 1,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store2,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 4 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 1,
-            zoom: 2,
             mask: 1 << 1,
         },
-        PhrasematchResults {
+        PhrasematchSubquery {
             id: 0,
-            scorefactor: 0,
-            prefix: 0,
-            nmask: 2,
-            bmask: HashSet::new(),
-            edit_multiplier: 1.0,
-            subquery_edit_distance: 0,
             store: &store3,
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 4 },
                 lang_set: ALL_LANGUAGES,
             },
-            idx: 2,
-            zoom: 5,
             mask: 1 << 0,
         },
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0.0, 0);
+    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -40,7 +40,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -57,7 +57,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -74,7 +74,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -91,7 +91,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -131,7 +131,7 @@ fn coalesce_single_test_proximity_basic() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -179,7 +179,7 @@ fn coalesce_single_test_language_penalty() {
     let stack = vec![subquery.clone()];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -194,7 +194,7 @@ fn coalesce_single_test_language_penalty() {
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -266,7 +266,7 @@ fn coalesce_multi_test_language_penalty() {
 
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -283,7 +283,7 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -324,7 +324,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -380,7 +380,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with proximity");
     let match_opts = MatchOpts { zoom: 6, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -470,7 +470,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -505,7 +505,7 @@ fn coalesce_single_test() {
     println!("Coalesce single - with bbox and proximity");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), proximity: Some([1, 1]) };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -569,7 +569,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -609,7 +609,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -649,7 +649,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -737,7 +737,7 @@ fn coalesce_multi_test() {
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
@@ -835,7 +835,7 @@ fn coalesce_multi_test() {
     println!("Coalesce multi - with proximity");
     let match_opts = MatchOpts { zoom: 2, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
@@ -1011,7 +1011,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1061,7 +1061,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1111,7 +1111,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1200,7 +1200,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity very close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4601, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
@@ -1215,7 +1215,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity less close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4610, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
@@ -1300,7 +1300,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
@@ -1318,7 +1318,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
@@ -1337,7 +1337,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
@@ -1378,7 +1378,7 @@ fn coalesce_multi_test_bbox() {
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&vec![stack.clone()], None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");


### PR DESCRIPTION
This branch does a few of main things:
- [x] recombines the PhrasematchSubquery and PhrasematchResults types back into one type that everything can use
- [x] moves all the properties that are always the same for every phrasematch for a given store into the store and out of the phrasematch type (so, idx, zoom, etc.)
- [x] flatten the input for stackable and stack_and_coalesce to just be an array of phrasematches, rather than an array of arrays

One other thing: it looks like since I had forked off, a parameter was added to stackable stackable and a field was added to StackableNode that had the phrasematch ID in it. Per chat, I'm using the phrasematch ID field on the phrasematch instead here.

After that, most of what's here is just propagating those changes outwards. Some comments inline below.