### PR TITLE
Add field that indicates depth of node in the tree

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -513,7 +513,7 @@ pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let js_phrasematch_result = { cx.argument::<JsArray>(0)? };
     let phrasematch_results: Vec<PhrasematchSubquery<ArcGridStore>> =
         deserialize_phrasesubq(&mut cx, js_phrasematch_result)?;
-    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
 
     Ok(cx.undefined())
 }

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -595,6 +595,6 @@ pub fn stack_and_coalesce<T: Borrow<GridStore> + Clone + Debug>(
 ) -> Result<Vec<CoalesceContext>, Error> {
     // currently stackable requires double-wrapping the phrasematches vector, which requires an
     // extra clone; ideally we wouldn't do that
-    let tree = stackable(phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     tree_coalesce(&tree, &match_opts)
 }

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -40,7 +40,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -57,7 +57,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -74,7 +74,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -91,7 +91,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -131,7 +131,7 @@ fn coalesce_single_test_proximity_basic() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -179,7 +179,7 @@ fn coalesce_single_test_language_penalty() {
     let stack = vec![subquery.clone()];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -194,7 +194,7 @@ fn coalesce_single_test_language_penalty() {
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -266,7 +266,7 @@ fn coalesce_multi_test_language_penalty() {
 
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -283,7 +283,7 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -324,7 +324,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -380,7 +380,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with proximity");
     let match_opts = MatchOpts { zoom: 6, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -470,7 +470,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -505,7 +505,7 @@ fn coalesce_single_test() {
     println!("Coalesce single - with bbox and proximity");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), proximity: Some([1, 1]) };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -569,7 +569,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -609,7 +609,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -649,7 +649,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -737,7 +737,7 @@ fn coalesce_multi_test() {
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
@@ -835,7 +835,7 @@ fn coalesce_multi_test() {
     println!("Coalesce multi - with proximity");
     let match_opts = MatchOpts { zoom: 2, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
@@ -1011,7 +1011,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1061,7 +1061,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1111,7 +1111,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1200,7 +1200,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity very close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4601, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
@@ -1215,7 +1215,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity less close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4610, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
@@ -1300,7 +1300,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
@@ -1318,7 +1318,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
@@ -1337,7 +1337,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
@@ -1378,7 +1378,7 @@ fn coalesce_multi_test_bbox() {
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0, 0);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");


### PR DESCRIPTION
### Context
While coalescing the stacks it would be good to know if a node has no parent or child making it the perfect candidate for the `coalecse_single()` (coalesce's a single stack) operation. This PR adds a depth field to the node which can be used along with the function `is_leaf()`to determine whether the node is a good candidate for `coalesce _single()`. Note: The depth of the root node will always be 0. 

cc @apendleton 