### PR TITLE
Put idx back

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -79,10 +79,8 @@ type KeyIterator = OwningHandle<ArcGridStore, Box<dyn Iterator<Item=Result<GridK
 
 #[derive(Deserialize, Debug, PartialEq, Clone)]
 struct GridStoreOpts {
-    pub idx: u16,
     pub zoom: u16,
     pub type_id: u16,
-    pub non_overlapping_indexes: HashSet<u16>, // the field formerly known as bmask
     pub coalesce_radius: f64,
 }
 
@@ -287,10 +285,8 @@ declare_types! {
 
                     GridStore::new_with_options(
                         filename,
-                        opts.idx,
                         opts.zoom,
                         opts.type_id,
-                        opts.non_overlapping_indexes,
                         opts.coalesce_radius
                     )
                 },
@@ -497,12 +493,18 @@ where
 
         let id = js_phrasematch.get(cx, "id")?;
 
+        let idx = js_phrasematch.get(cx, "idx")?;
+
+        let non_overlapping_indexes = js_phrasematch.get(cx, "non_overlapping_indexes")?;
+
         let subq = PhrasematchSubquery {
             store: gridstore,
             weight: neon_serde::from_value(cx, weight)?,
             match_key: MatchKey { match_phrase: neon_serde::from_value(cx, match_phrase)?, lang_set },
             mask: neon_serde::from_value(cx, mask)?,
             id: neon_serde::from_value(cx, id)?,
+            idx: neon_serde::from_value(cx, idx)?,
+            non_overlapping_indexes: neon_serde::from_value(cx, non_overlapping_indexes)?,
         };
         phrasematches.push(subq);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-stack-and-coalesce-4",
+  "version": "0.1.1-put-idx-back-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -58,8 +58,8 @@ fn grid_to_coalesce_entry<T: Borrow<GridStore> + Clone>(
     CoalesceEntry {
         grid_entry: GridEntry { relev: relevance, ..grid.grid_entry },
         matches_language: grid.matches_language,
-        idx: subquery.store.borrow().idx,
-        tmp_id: ((subquery.store.borrow().idx as u32) << 25) + grid.grid_entry.id,
+        idx: subquery.idx,
+        tmp_id: ((subquery.idx as u32) << 25) + grid.grid_entry.id,
         mask: subquery.mask,
         distance: grid.distance,
         scoredist: grid.scoredist,
@@ -174,7 +174,7 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
     mut stack: Vec<PhrasematchSubquery<T>>,
     match_opts: &MatchOpts,
 ) -> Result<Vec<CoalesceContext>, Error> {
-    stack.sort_by_key(|subquery| (subquery.store.borrow().zoom, subquery.store.borrow().idx));
+    stack.sort_by_key(|subquery| (subquery.store.borrow().zoom, subquery.idx));
 
     let mut coalesced: HashMap<(u16, u16, u16), Vec<CoalesceContext>> = HashMap::new();
     let mut contexts: Vec<CoalesceContext> = Vec::new();
@@ -189,7 +189,7 @@ fn coalesce_multi<T: Borrow<GridStore> + Clone>(
         let compatible_zooms: Vec<u16> = stack
             .iter()
             .filter_map(|subquery_b| {
-                if subquery.store.borrow().idx == subquery_b.store.borrow().idx
+                if subquery.idx == subquery_b.idx
                     || subquery.store.borrow().zoom < subquery_b.store.borrow().zoom
                 {
                     None

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::collections::HashSet;
 
 use crate::gridstore::store::GridStore;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -376,6 +377,8 @@ fn serialize_path<S: Serializer, T: Borrow<GridStore>>(store: &T, s: S) -> Resul
 pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
     #[serde(serialize_with = "serialize_path")]
     pub store: T,
+    pub idx: u16,
+    pub non_overlapping_indexes: HashSet<u16>, // the field formerly known as bmask
     pub weight: f64,
     pub match_key: MatchKey,
     pub mask: u32,

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -193,8 +193,7 @@ mod tests {
 
         builder.finish().unwrap();
 
-        let reader =
-            GridStore::new_with_options(directory.path(), 0, 14, 0, HashSet::new(), 1000.).unwrap();
+        let reader = GridStore::new_with_options(directory.path(), 14, 0, 1000.).unwrap();
 
         let search_key =
             MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
@@ -507,24 +506,10 @@ mod tests {
         builder_with_boundaries.finish().unwrap();
         builder_without_boundaries.finish().unwrap();
 
-        let reader_with_boundaries = GridStore::new_with_options(
-            directory_with_boundaries.path(),
-            0,
-            14,
-            0,
-            HashSet::new(),
-            200.,
-        )
-        .unwrap();
-        let reader_without_boundaries = GridStore::new_with_options(
-            directory_without_boundaries.path(),
-            0,
-            14,
-            0,
-            HashSet::new(),
-            200.,
-        )
-        .unwrap();
+        let reader_with_boundaries =
+            GridStore::new_with_options(directory_with_boundaries.path(), 14, 0, 200.).unwrap();
+        let reader_without_boundaries =
+            GridStore::new_with_options(directory_without_boundaries.path(), 14, 0, 200.).unwrap();
 
         (
             reader_with_boundaries,
@@ -659,6 +644,8 @@ mod tests {
             let subquery = PhrasematchSubquery {
                 id: 0,
                 store: reader,
+                idx: 1,
+                non_overlapping_indexes: HashSet::new(),
                 weight: 1.,
                 match_key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: range.0, end: range.1 },

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -69,7 +69,7 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
             if node.zoom > phrasematches.store.borrow().zoom {
                 continue;
             } else if node.zoom == phrasematches.store.borrow().zoom {
-                if node.idx > phrasematches.store.borrow().idx {
+                if node.idx > phrasematches.idx {
                     continue;
                 }
             }
@@ -77,13 +77,13 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
 
         if (node.nmask & (1u32 << phrasematches.store.borrow().type_id)) == 0
             && (node.mask & phrasematches.mask) == 0
-            && phrasematches.store.borrow().non_overlapping_indexes.contains(&node.idx) == false
+            && phrasematches.non_overlapping_indexes.contains(&node.idx) == false
         {
             let target_nmask = &(1u32 << phrasematches.store.borrow().type_id) | node.nmask;
             let target_mask = &phrasematches.mask | node.mask;
             let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
             let phrasematch_bmask: HashSet<u16> =
-                phrasematches.store.borrow().non_overlapping_indexes.iter().cloned().collect();
+                phrasematches.non_overlapping_indexes.iter().cloned().collect();
             target_bmask.extend(&phrasematch_bmask);
             let target_relev = 0.0 + &phrasematches.weight;
 
@@ -93,7 +93,7 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
                 target_nmask,
                 target_bmask,
                 target_mask,
-                phrasematches.store.borrow().idx,
+                phrasematches.idx,
                 target_relev,
                 phrasematches.store.borrow().zoom,
             ));
@@ -129,14 +129,14 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store1 =
-            GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
-        let store2 =
-            GridStore::new_with_options(directory.path(), 2, 14, 2, HashSet::new(), 200.).unwrap();
+        let store1 = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+        let store2 = GridStore::new_with_options(directory.path(), 14, 2, 200.).unwrap();
 
         let a1 = PhrasematchSubquery {
             id: 0,
             store: &store1,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 2,
@@ -145,6 +145,8 @@ mod test {
         let b1 = PhrasematchSubquery {
             id: 1,
             store: &store2,
+            idx: 2,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -153,6 +155,8 @@ mod test {
         let b2 = PhrasematchSubquery {
             id: 2,
             store: &store2,
+            idx: 2,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -203,6 +207,8 @@ mod test {
         let a1 = PhrasematchSubquery {
             id: 0,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -211,6 +217,8 @@ mod test {
         let b1 = PhrasematchSubquery {
             id: 1,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -247,6 +255,8 @@ mod test {
         let a1 = PhrasematchSubquery {
             id: 0,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -255,6 +265,8 @@ mod test {
         let b1 = PhrasematchSubquery {
             id: 1,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -285,6 +297,8 @@ mod test {
         let a1 = PhrasematchSubquery {
             id: 0,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,
@@ -293,6 +307,8 @@ mod test {
         let b1 = PhrasematchSubquery {
             id: 1,
             store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
             weight: 0.5,
             match_key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
             mask: 1,

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -21,10 +21,8 @@ pub struct GridStore {
     bin_boundaries: HashSet<u32>,
     pub path: PathBuf,
     // options:
-    pub idx: u16,
     pub zoom: u16,
     pub type_id: u16,
-    pub non_overlapping_indexes: HashSet<u16>, // the field formerly known as bmask
     pub coalesce_radius: f64,
 }
 
@@ -251,15 +249,13 @@ impl<T: Iterator<Item = MatchEntry>> Eq for QueueElement<T> {}
 
 impl GridStore {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        GridStore::new_with_options(path, 0, 6, 0, HashSet::new(), 0.0)
+        GridStore::new_with_options(path, 6, 0, 0.0)
     }
 
     pub fn new_with_options<P: AsRef<Path>>(
         path: P,
-        idx: u16,
         zoom: u16,
         type_id: u16,
-        non_overlapping_indexes: HashSet<u16>,
         coalesce_radius: f64,
     ) -> Result<Self, Error> {
         let path = path.as_ref().to_owned();
@@ -285,16 +281,7 @@ impl GridStore {
             None => HashSet::new(),
         };
 
-        Ok(GridStore {
-            db,
-            path,
-            bin_boundaries,
-            idx,
-            zoom,
-            type_id,
-            non_overlapping_indexes,
-            coalesce_radius,
-        })
+        Ok(GridStore { db, path, bin_boundaries, zoom, type_id, coalesce_radius })
     }
 
     #[inline(never)]

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -134,6 +134,7 @@ tape('Coalesce tests - invalid inputs', (t) => {
     // no weight
     const no_weight = [{
         store: reader,
+		non_overlapping_indexes: [],
         match_key: {
             lang_set: [0],
             match_phrase: {
@@ -170,6 +171,7 @@ tape('Coalesce tests - invalid inputs', (t) => {
 
     const no_match_key = [{
         store: reader,
+        non_overlapping_indexes: [],
         weight: 0.5,
         idx: 2,
         zoom: 6,
@@ -179,6 +181,7 @@ tape('Coalesce tests - invalid inputs', (t) => {
 
     const no_idx = [{
         store: reader,
+        non_overlapping_indexes: [],
         weight: 0.5,
         match_key: {
             lang_set: [0],
@@ -196,6 +199,7 @@ tape('Coalesce tests - invalid inputs', (t) => {
 
     const no_mask = [{
         store: reader,
+        non_overlapping_indexes: [],
         weight: 0.5,
         match_key: {
             lang_set: [0],
@@ -223,10 +227,12 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
         ]
     );
     builder.finish();
-    const reader = new addon.GridStore(tmpDir.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
+    const readerOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+	const reader = new addon.GridStore(tmpDir.name, readerOpts);
 
     const valid_stack = [{
         store: reader,
+        non_overlapping_indexes: [],
         weight: 1,
         match_key: {
             lang_set: [1],
@@ -271,7 +277,8 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder1.finish();
-    const reader1 = new addon.GridStore(tmpDir1.name, { idx: 0, zoom: 1, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
+    const reader1Opts = { idx: 0, zoom: 1, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+	const reader1 = new addon.GridStore(tmpDir1.name, reader1Opts);
 
     const tmpDir2 = tmp.dirSync();
     const builder2 = new addon.GridStoreBuilder(tmpDir2.name);
@@ -282,10 +289,12 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder2.finish();
-    const reader2 = new addon.GridStore(tmpDir2.name, { idx: 1, zoom: 2, non_overlapping_indexes: Array.from(new Set()), type_id: 1, coalesce_radius: 200 });
+    const reader2Opts = { idx: 1, zoom: 2, non_overlapping_indexes: Array.from(new Set()), type_id: 1, coalesce_radius: 200 };
+	const reader2 = new addon.GridStore(tmpDir2.name, reader2Opts);
 
     const valid_coalesce_multi = [{
         store: reader1,
+		non_overlapping_indexes: reader1Opts.non_overlapping_indexes,
         weight: 0.5,
         match_key: {
             lang_set: [1],
@@ -302,6 +311,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         id: 0
     },{
         store: reader2,
+		non_overlapping_indexes: reader2Opts.non_overlapping_indexes,
         weight: 0.5,
         match_key: {
             lang_set: [1],
@@ -337,6 +347,7 @@ tape('lang_set >= 128', (t) => {
 
     const lang_set_stack = [{
         store: reader,
+		non_overlapping_indexes: [],
         weight: 1,
         match_key: {
             lang_set: [128],
@@ -413,8 +424,10 @@ tape('Bin boundaries', (t) => {
     builderWithBoundaries.finish();
     builderWithoutBoundaries.finish();
 
-    const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
-    const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
+    const readerWithBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+	const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, readerWithBoundariesOpts);
+    const readerWithoutBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+	const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, readerWithoutBoundariesOpts);
 
     const findRange = (prefix) => {
         let start = null,
@@ -441,6 +454,7 @@ tape('Bin boundaries', (t) => {
     ].forEach(({ reader, range }) => {
         const subquery = {
             store: reader,
+		    non_overlapping_indexes: [],
             weight: 1.,
             match_key: { match_phrase: { "Range": range }, lang_set: [1] },
             idx: 1,
@@ -472,9 +486,10 @@ tape('Deserialize phrasematch results', (t) => {
         ]
     );
     builder.finish();
-    const store = new addon.GridStore(tmpDir.name, { idx: 0, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 });
+    const storeOpts = { idx: 0, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+	const store = new addon.GridStore(tmpDir.name, storeOpts);
     let phrasematchResults = [
-        new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1)
+        new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1, 0, [])
     ];
     addon.stackable(phrasematchResults);
     t.end();
@@ -482,7 +497,7 @@ tape('Deserialize phrasematch results', (t) => {
 
 
 
-function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, editMultiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages, id) {
+function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, editMultiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages, id, idx, non_overlapping_indexes) {
     this.store = store;
     this.subquery = subquery;
     this.phrase = phrase;
@@ -501,6 +516,8 @@ function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefact
     this.original_phrase_ender = original_phrase_ender;
     this.original_phrase_mask = original_phrase_mask;
     this.id = id;
+    this.idx = idx;
+    this.non_overlapping_indexes = [];
 
     if (languages) {
         // carmen-cache gives special treatment to the "languages" property
@@ -519,9 +536,5 @@ function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefact
         }
     };
 }
-
-Phrasematch.prototype.clone = function() {
-    return new Phrasematch(this.store, this.subquery.slice(), this.phrase, this.weight, this.phrase_id_range, this.scorefactor, this.prefix, this.mask, this.zoom, this.editMultiplier, this.prox_match, this.cat_match, this.partial_number, this.subquery_edit_distance, this.original_phrase, this.original_phrase_ender, this.original_phrase_mask, this.languages, this.id);
-};
 
 module.exports.Phrasematch = Phrasematch;

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -22,11 +22,12 @@ fn coalesce_single_test_proximity_quadrants() {
 
     builder.finish().unwrap();
 
-    let store =
-        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         mask: 1 << 0,
@@ -119,11 +120,12 @@ fn coalesce_single_test_proximity_basic() {
 
     builder.finish().unwrap();
 
-    let store =
-        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 200.).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         mask: 1 << 0,
@@ -167,11 +169,12 @@ fn coalesce_single_test_language_penalty() {
     builder.insert(&key, entries).expect("Unable to insert record");
     builder.finish().unwrap();
 
-    let store =
-        GridStore::new_with_options(directory.path(), 1, 14, 1, HashSet::new(), 1.).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 14, 1, 1.).unwrap();
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 },
         mask: 1 << 0,
@@ -244,7 +247,9 @@ fn coalesce_multi_test_language_penalty() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -254,7 +259,9 @@ fn coalesce_multi_test_language_penalty() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -313,7 +320,9 @@ fn coalesce_single_test() {
     );
     let subquery = PhrasematchSubquery {
         id: 0,
-        store: &store,
+        store: &store.store,
+        idx: store.idx,
+        non_overlapping_indexes: store.non_overlapping_indexes.clone(),
         weight: 1.,
         match_key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         mask: 1 << 0,
@@ -552,13 +561,14 @@ fn coalesce_single_languages_test() {
     }
     builder.finish().unwrap();
 
-    let store =
-        GridStore::new_with_options(directory.path(), 1, 6, 1, HashSet::new(), 200.).unwrap();
+    let store = GridStore::new_with_options(directory.path(), 6, 1, 200.).unwrap();
     // Test query with all languages
     println!("Coalesce single - all languages");
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -599,6 +609,8 @@ fn coalesce_single_languages_test() {
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -639,6 +651,8 @@ fn coalesce_single_languages_test() {
     let subquery = PhrasematchSubquery {
         id: 0,
         store: &store,
+        idx: 1,
+        non_overlapping_indexes: HashSet::new(),
         weight: 1.,
         match_key: MatchKey {
             match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -713,7 +727,9 @@ fn coalesce_multi_test() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -723,7 +739,9 @@ fn coalesce_multi_test() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -990,7 +1008,9 @@ fn coalesce_multi_languages_test() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1000,7 +1020,9 @@ fn coalesce_multi_languages_test() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1040,7 +1062,9 @@ fn coalesce_multi_languages_test() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1050,7 +1074,9 @@ fn coalesce_multi_languages_test() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1090,7 +1116,9 @@ fn coalesce_multi_languages_test() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1100,7 +1128,9 @@ fn coalesce_multi_languages_test() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1177,7 +1207,9 @@ fn coalesce_multi_scoredist() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1187,7 +1219,9 @@ fn coalesce_multi_scoredist() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1277,7 +1311,9 @@ fn coalesce_multi_test_bbox() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store1,
+            store: &store1.store,
+            idx: store1.idx,
+            non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1287,7 +1323,9 @@ fn coalesce_multi_test_bbox() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1357,7 +1395,9 @@ fn coalesce_multi_test_bbox() {
     let stack = vec![
         PhrasematchSubquery {
             id: 0,
-            store: &store2,
+            store: &store2.store,
+            idx: store2.idx,
+            non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 4 },
@@ -1367,7 +1407,9 @@ fn coalesce_multi_test_bbox() {
         },
         PhrasematchSubquery {
             id: 0,
-            store: &store3,
+            store: &store3.store,
+            idx: store3.idx,
+            non_overlapping_indexes: store3.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 4 },


### PR DESCRIPTION
#72 moved some properties from phrasematches into the gridstore under the theory that for a given gridstore, these values would always be the same. It turns out that under some circumstances, `idx` and `non_overlapping_indexes` might differ for the same store if a single store is reused with multiple Carmen endpoints. This branch moves these values back onto the Phrasematch subquery object, and updates all tests and callers accordingly.