### PR TITLE
stackable benchmarking

### DIFF
--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -40,7 +40,14 @@ pub fn benchmark(c: &mut Criterion) {
         );
     }
 
-    let to_bench = vec![("stackable_us_address", "us-address-forward.ljson.lz4")];
+    let to_bench = vec![
+        ("stackable_us_address", "us-address-forward.ljson.lz4"),
+        ("stackable_us_address_postcode", "us-address-postcode.ljson.lz4"),
+        (
+            "stackable_us-address_postcode_place_region",
+            "us-address-postcode-place-region.ljson.lz4",
+        ),
+    ];
 
     for (label, file) in to_bench {
         c.bench(
@@ -56,7 +63,7 @@ pub fn benchmark(c: &mut Criterion) {
                     stackable(&pm, None, 0, HashSet::new(), 0, 129, 0.0, 0)
                 })
             })
-            .sample_size(10),
+            .sample_size(20),
         );
     }
 }

--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -39,4 +39,24 @@ pub fn benchmark(c: &mut Criterion) {
             .sample_size(20),
         );
     }
+
+    let to_bench = vec![("stackable_us_address", "us-address-forward.ljson.lz4")];
+
+    for (label, file) in to_bench {
+        c.bench(
+            label,
+            Benchmark::new(label, move |b: &mut Bencher| {
+                let queries = prepare_stackable_phrasematches(file);
+                let collapsed: Vec<_> =
+                    queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
+                let mut cycle = collapsed.iter().cycle();
+
+                b.iter(|| {
+                    let pm = cycle.next().unwrap();
+                    stackable(&pm, None, 0, HashSet::new(), 0, 129, 0.0, 0)
+                })
+            })
+            .sample_size(10),
+        );
+    }
 }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -289,6 +289,8 @@ pub fn prepare_stackable_phrasematches(
                     .map(|placeholder| {
                         let store =
                             stores.entry(placeholder.store.path.clone()).or_insert_with(|| {
+                                // since stackable doesn't really need the actual gridstore data
+                                // we're using aa-country in order to avoid having to download gridstore data from every index
                                 let store_name =
                                     "aa-country-both-3e43d23805-069d003ff2.gridstore.dat.lz4";
                                 let store_path = ensure_store(&store_name);


### PR DESCRIPTION
## Context
We need a good way to benchmark stackable to help guide performance improvements. Since, stackable doesn't actually interact with the gridstore, I've hardcoded the `aa-country` gridstore (thanks for the tip @apendleton) instead having to download and dump a number of stores from every index. This PR will add benchmarks for forward us-address, us-address-postcode queries, which seem to be the slowest in our search engine.


cc @apendleton (once you merge in grouped-phrasematch, I'll base this PR off of treeify-stacks)