### PR TITLE
Unified binned stackable

### DIFF
--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -56,13 +56,16 @@ pub fn benchmark(c: &mut Criterion) {
                 let queries = prepare_stackable_phrasematches(file);
                 let collapsed: Vec<_> =
                     queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
-                let binned_phrasematches: Vec<_> =
-                    collapsed.into_iter().map(|b| binned_phrasematches(b)).collect();
+                let binned_phrasematches: Vec<_> = collapsed
+                    .into_iter()
+                    .map(|b| binned_phrasematches(b).into_iter().map(|(_k, v)| v).collect())
+                    .collect();
+
                 let mut cycle = binned_phrasematches.iter().cycle();
 
                 b.iter(|| {
                     let pm = cycle.next().unwrap();
-                    binned_stackable(pm, None, HashSet::new(), 0, 129, 0.0, 0)
+                    binned_stackable(&pm, None, HashSet::new(), 0, 129, 0.0, 0, 0)
                 })
             })
             .sample_size(2),

--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use criterion::{Bencher, Benchmark, Criterion};
 
 use carmen_core::gridstore::*;
@@ -25,7 +23,7 @@ pub fn benchmark(c: &mut Criterion) {
                 let trees: Vec<_> = collapsed
                     .iter()
                     .map(|(query, opts)| {
-                        (stackable(query, None, 0, HashSet::new(), 0, 129, 0.0, 0), opts)
+                        (stackable(query), opts)
                     })
                     .collect();
 
@@ -56,19 +54,15 @@ pub fn benchmark(c: &mut Criterion) {
                 let queries = prepare_stackable_phrasematches(file);
                 let collapsed: Vec<_> =
                     queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
-                let binned_phrasematches: Vec<_> = collapsed
-                    .into_iter()
-                    .map(|b| binned_phrasematches(b).into_iter().map(|(_k, v)| v).collect())
-                    .collect();
 
-                let mut cycle = binned_phrasematches.iter().cycle();
+                let mut cycle = collapsed.iter().cycle();
 
                 b.iter(|| {
                     let pm = cycle.next().unwrap();
-                    binned_stackable(&pm, None, HashSet::new(), 0, 129, 0.0, 0, 0)
+                    stackable(&pm)
                 })
             })
-            .sample_size(2),
+            .sample_size(20),
         );
     }
 }

--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -20,12 +20,8 @@ pub fn benchmark(c: &mut Criterion) {
                     .into_iter()
                     .map(|(query, opts)| (collapse_phrasematches(query), opts))
                     .collect();
-                let trees: Vec<_> = collapsed
-                    .iter()
-                    .map(|(query, opts)| {
-                        (stackable(query), opts)
-                    })
-                    .collect();
+                let trees: Vec<_> =
+                    collapsed.iter().map(|(query, opts)| (stackable(query), opts)).collect();
 
                 let mut cycle = trees.iter().cycle();
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -517,7 +517,7 @@ pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     let js_phrasematch_result = { cx.argument::<JsArray>(0)? };
     let phrasematch_results: Vec<PhrasematchSubquery<ArcGridStore>> =
         deserialize_phrasesubq(&mut cx, js_phrasematch_result)?;
-    stackable(&phrasematch_results, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    stackable(&phrasematch_results);
 
     Ok(cx.undefined())
 }

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -643,7 +643,7 @@ pub fn stack_and_coalesce<T: Borrow<GridStore> + Clone + Debug>(
     // currently stackable requires double-wrapping the phrasematches vector, which requires an
     // extra clone; ideally we wouldn't do that
     let collapsed_phrasematches = collapse_phrasematches(phrasematches.to_vec());
-    let tree = stackable(&collapsed_phrasematches, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&collapsed_phrasematches);
     tree_coalesce(&tree, &match_opts)
 }
 

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -9,7 +9,7 @@ mod store;
 pub use builder::*;
 pub use coalesce::{coalesce, collapse_phrasematches, stack_and_coalesce, tree_coalesce};
 pub use common::*;
-pub use stackable::{binned_stackable, stackable};
+pub use stackable::stackable;
 pub use store::*;
 
 #[cfg(test)]

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -142,7 +142,8 @@ pub fn binned_stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
         zoom: zoom,
     };
 
-    for (type_idx, phrasematch_group) in binned_phrasematch.iter().enumerate().skip(start_type_idx) {
+    for (type_idx, phrasematch_group) in binned_phrasematch.iter().enumerate().skip(start_type_idx)
+    {
         for phrasematches in phrasematch_group.iter() {
             if (node.mask & phrasematches.mask) == 0
                 && phrasematches.non_overlapping_indexes.contains(&node.idx) == false
@@ -162,7 +163,7 @@ pub fn binned_stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
                     phrasematches.idx,
                     target_relev,
                     phrasematches.store.borrow().zoom,
-                    type_idx + 1
+                    type_idx + 1,
                 ));
             }
         }
@@ -247,81 +248,90 @@ mod test {
         let binned_phrasematch: Vec<_> = binned_phrasematch.into_iter().map(|(_k, v)| v).collect();
 
         let tree = binned_stackable(&binned_phrasematch, None, HashSet::new(), 0, 129, 0.0, 0, 0);
-        println!("{:?}", tree);
-        // let a1_children_ids: Vec<u32> = tree.clone().children[0]
-        //     .clone()
-        //     .children
-        //     .iter()
-        //     .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
-        //     .collect();
-        // assert_eq!(vec![1, 2], a1_children_ids, "a1 can stack with b1 and b2");
-        // let b1_children_ids: Vec<u32> = tree.clone().children[1]
-        //     .clone()
-        //     .children
-        //     .iter()
-        //     .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
-        //     .collect();
-        // assert_eq!(0, b1_children_ids.len(), "b1 cannot stack with b2, same nmask");
-        // let b2_children_ids: Vec<u32> = tree.clone().children[2]
-        //     .clone()
-        //     .children
-        //     .iter()
-        //     .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
-        //     .collect();
-        // assert_eq!(0, b2_children_ids.len(), "b2 cannot stack with b1, same nmask");
+        let a1_children_ids: Vec<u32> = tree.clone().children[0]
+            .clone()
+            .children
+            .iter()
+            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .collect();
+        assert_eq!(vec![1, 2], a1_children_ids, "a1 can stack with b1 and b2");
+        let b1_children_ids: Vec<u32> = tree.clone().children[1]
+            .clone()
+            .children
+            .iter()
+            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .collect();
+        assert_eq!(0, b1_children_ids.len(), "b1 cannot stack with b2, same nmask");
+        let b2_children_ids: Vec<u32> = tree.clone().children[2]
+            .clone()
+            .children
+            .iter()
+            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .collect();
+        assert_eq!(0, b2_children_ids.len(), "b2 cannot stack with b1, same nmask");
     }
 
-    // #[test]
-    // fn bmask_stackable_test() {
-    //     let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
-    //     let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
-    //
-    //     let key = GridKey { phrase_id: 1, lang_set: 1 };
-    //
-    //     let entries = vec![
-    //         GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
-    //         GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 1 },
-    //         GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
-    //     ];
-    //     builder.insert(&key, entries).expect("Unable to insert record");
-    //     builder.finish().unwrap();
-    //     let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
-    //     let mut a1_bmask: HashSet<u16> = HashSet::new();
-    //     a1_bmask.insert(0);
-    //     a1_bmask.insert(1);
-    //     let mut b1_bmask: HashSet<u16> = HashSet::new();
-    //     b1_bmask.insert(1);
-    //     b1_bmask.insert(0);
-    //
-    //     let a1 = PhrasematchSubquery {
-    //         store: &store,
-    //         idx: 1,
-    //         non_overlapping_indexes: HashSet::new(),
-    //         weight: 0.5,
-    //         match_keys: vec![MatchKeyWithId {
-    //             key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
-    //             id: 0,
-    //         }],
-    //         mask: 1,
-    //     };
-    //
-    //     let b1 = PhrasematchSubquery {
-    //         store: &store,
-    //         idx: 1,
-    //         non_overlapping_indexes: HashSet::new(),
-    //         weight: 0.5,
-    //         match_keys: vec![MatchKeyWithId {
-    //             key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
-    //             id: 1,
-    //         }],
-    //         mask: 1,
-    //     };
-    //     let phrasematch_results = vec![a1, b1];
-    //     let tree = binned_stackable(&phrasematch_results, None, HashSet::new(), 0, 129, 0.0, 0);
-    //     let bmask_stacks: Vec<bool> = bfs(tree).iter().map(|node| node.is_leaf()).collect();
-    //     assert_eq!(bmask_stacks[1], true, "a1 cannot stack with b1 since a1's bmask contains the idx of b1 - so they don't have any children");
-    //     assert_eq!(bmask_stacks[2], true, "b1 cannot stack with a1 since b1's bmask contains the idx of a1 - so they don't have any children");
-    // }
+    #[test]
+    fn bmask_stackable_test() {
+        let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
+        let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
+
+        let key = GridKey { phrase_id: 1, lang_set: 1 };
+
+        let entries = vec![
+            GridEntry { id: 2, x: 2, y: 2, relev: 0.8, score: 3, source_phrase_hash: 0 },
+            GridEntry { id: 3, x: 3, y: 3, relev: 1., score: 1, source_phrase_hash: 1 },
+            GridEntry { id: 1, x: 1, y: 1, relev: 1., score: 7, source_phrase_hash: 2 },
+        ];
+        builder.insert(&key, entries).expect("Unable to insert record");
+        builder.finish().unwrap();
+        let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+        let mut a1_bmask: HashSet<u16> = HashSet::new();
+        a1_bmask.insert(0);
+        a1_bmask.insert(1);
+        let mut b1_bmask: HashSet<u16> = HashSet::new();
+        b1_bmask.insert(1);
+        b1_bmask.insert(0);
+
+        let a1 = PhrasematchSubquery {
+            store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
+            weight: 0.5,
+            match_keys: vec![MatchKeyWithId {
+                key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
+                id: 0,
+            }],
+            mask: 1,
+        };
+
+        let b1 = PhrasematchSubquery {
+            store: &store,
+            idx: 1,
+            non_overlapping_indexes: HashSet::new(),
+            weight: 0.5,
+            match_keys: vec![MatchKeyWithId {
+                key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
+                id: 1,
+            }],
+            mask: 1,
+        };
+        let phrasematch_results = vec![a1, b1];
+        let mut binned_phrasematch: BTreeMap<u16, Vec<PhrasematchSubquery<&GridStore>>> =
+            BTreeMap::new();
+        for phrasematch in phrasematch_results {
+            binned_phrasematch
+                .entry(phrasematch.store.borrow().type_id)
+                .or_insert(Vec::new())
+                .push(phrasematch);
+        }
+        let binned_phrasematch: Vec<_> = binned_phrasematch.into_iter().map(|(_k, v)| v).collect();
+        let tree = binned_stackable(&binned_phrasematch, None, HashSet::new(), 0, 129, 0.0, 0, 0);
+
+        let bmask_stacks: Vec<bool> = bfs(tree).iter().map(|node| node.is_leaf()).collect();
+        assert_eq!(bmask_stacks[1], true, "a1 cannot stack with b1 since a1's bmask contains the idx of b1 - so they don't have any children");
+        assert_eq!(bmask_stacks[2], true, "b1 cannot stack with a1 since b1's bmask contains the idx of a1 - so they don't have any children");
+    }
 
     // #[test]
     // fn mask_stackable_test() {

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use std::borrow::Borrow;
-use std::collections::{HashSet, BTreeMap};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 
 use crate::gridstore::common::*;
@@ -24,9 +24,7 @@ impl<'a, T: Borrow<GridStore> + Clone + Debug> StackableNode<'a, T> {
 }
 
 //tree traversal used only for tests
-pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(
-    root: StackableNode<T>,
-) -> Vec<StackableNode<T>> {
+pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(root: StackableNode<T>) -> Vec<StackableNode<T>> {
     let mut node_vec: Vec<StackableNode<T>> = vec![];
     let mut stack: Vec<_> = vec![];
 
@@ -45,8 +43,7 @@ pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(
 pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
     phrasematches: &'a Vec<PhrasematchSubquery<T>>,
 ) -> StackableNode<'a, T> {
-    let mut binned_phrasematches: BTreeMap<u16, Vec<&'a PhrasematchSubquery<T>>> =
-        BTreeMap::new();
+    let mut binned_phrasematches: BTreeMap<u16, Vec<&'a PhrasematchSubquery<T>>> = BTreeMap::new();
     for phrasematch in phrasematches {
         binned_phrasematches
             .entry(phrasematch.store.borrow().type_id)

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -11,7 +11,7 @@ use rusoto_core::Region;
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use serde::{Deserialize, Serialize};
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufWriter, Read, Write};
@@ -320,16 +320,4 @@ pub fn prepare_stackable_phrasematches(
         })
         .collect();
     out
-}
-
-pub fn binned_phrasematches(
-    pms: Vec<PhrasematchSubquery<Rc<GridStore>>>,
-) -> BTreeMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> {
-    let mut binned_phrasematch: BTreeMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> =
-        BTreeMap::new();
-
-    for pm in pms {
-        binned_phrasematch.entry(pm.store.type_id).or_insert(Vec::new()).push(pm)
-    }
-    binned_phrasematch
 }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -11,7 +11,7 @@ use rusoto_core::Region;
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use serde::{Deserialize, Serialize};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufWriter, Read, Write};
@@ -324,13 +324,12 @@ pub fn prepare_stackable_phrasematches(
 
 pub fn binned_phrasematches(
     pms: Vec<PhrasematchSubquery<Rc<GridStore>>>,
-) -> HashMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> {
-    let mut binned_phrasematch: HashMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> =
-        HashMap::new();
+) -> BTreeMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> {
+    let mut binned_phrasematch: BTreeMap<u16, Vec<PhrasematchSubquery<Rc<GridStore>>>> =
+        BTreeMap::new();
 
     for pm in pms {
         binned_phrasematch.entry(pm.store.type_id).or_insert(Vec::new()).push(pm)
     }
-
     binned_phrasematch
 }

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -43,7 +43,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -60,7 +60,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -77,7 +77,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -94,7 +94,7 @@ fn coalesce_single_test_proximity_quadrants() {
         ..MatchOpts::default()
     };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -137,7 +137,7 @@ fn coalesce_single_test_proximity_basic() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     let result_ids: Vec<u32> =
@@ -188,7 +188,7 @@ fn coalesce_single_test_language_penalty() {
     let stack = vec![subquery.clone()];
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -203,7 +203,7 @@ fn coalesce_single_test_language_penalty() {
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let stack = vec![subquery.clone()];
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -227,7 +227,7 @@ fn coalesce_multi_test_language_penalty() {
         }],
         1,
         14,
-        0,
+        1,
         HashSet::new(),
         200.,
     );
@@ -243,7 +243,7 @@ fn coalesce_multi_test_language_penalty() {
         }],
         2,
         6,
-        1,
+        0,
         HashSet::new(),
         200.,
     );
@@ -283,7 +283,7 @@ fn coalesce_multi_test_language_penalty() {
 
     let match_opts = MatchOpts { zoom: 14, proximity: Some([2, 2]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -300,7 +300,7 @@ fn coalesce_multi_test_language_penalty() {
     println!("Coalesce multi - Subqueires with different lang set from grids, no proximity");
     let match_opts = MatchOpts { zoom: 14, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -345,7 +345,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - no proximity, no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -401,7 +401,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with proximity");
     let match_opts = MatchOpts { zoom: 6, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -491,7 +491,7 @@ fn coalesce_single_test() {
     println!("Coalsece single - with bbox");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -526,7 +526,7 @@ fn coalesce_single_test() {
     println!("Coalesce single - with bbox and proximity");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([1, 1, 1, 1]), proximity: Some([1, 1]) };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries.len(), 1, "Only one result is within the bbox");
@@ -593,7 +593,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -637,7 +637,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -681,7 +681,7 @@ fn coalesce_single_languages_test() {
     let stack = vec![subquery];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
 
@@ -777,7 +777,7 @@ fn coalesce_multi_test() {
     println!("Coalsece multi - no proximity no bbox");
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result has relevance 1");
@@ -875,7 +875,7 @@ fn coalesce_multi_test() {
     println!("Coalesce multi - with proximity");
     let match_opts = MatchOpts { zoom: 2, proximity: Some([3, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].relev, 1., "1st result context has relevance 1");
@@ -1059,7 +1059,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1117,7 +1117,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1175,7 +1175,7 @@ fn coalesce_multi_languages_test() {
     ];
     let match_opts = MatchOpts { zoom: 6, ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     #[cfg_attr(rustfmt, rustfmt::skip)]
@@ -1272,7 +1272,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity very close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4601, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Closer feature is 1st");
@@ -1287,7 +1287,7 @@ fn coalesce_multi_scoredist() {
     println!("Coalesce multi - proximity less close to one grid");
     let match_opts = MatchOpts { zoom: 14, proximity: Some([4610, 6200]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     assert_eq!(result, tree_result);
     assert_eq!(result[0].entries[0].grid_entry.id, 3, "Farther feature with higher score is 1st");
@@ -1380,7 +1380,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at lower zoom of subquery");
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");
@@ -1398,7 +1398,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at higher zoom of subquery");
     let match_opts = MatchOpts { zoom: 2, bbox: Some([0, 0, 1, 3]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [2,0,0,1,3] - 2 results are within the bbox");
@@ -1417,7 +1417,7 @@ fn coalesce_multi_test_bbox() {
     println!("Coalesce multi - bbox at zoom 6");
     let match_opts = MatchOpts { zoom: 6, bbox: Some([14, 30, 15, 64]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [6,14,30,15,64] - 2 results are within the bbox");
@@ -1466,7 +1466,7 @@ fn coalesce_multi_test_bbox() {
     ];
     let match_opts = MatchOpts { zoom: 1, bbox: Some([0, 0, 1, 0]), ..MatchOpts::default() };
     let result = coalesce(stack.iter().map(|s| s.clone().into()).collect(), &match_opts).unwrap();
-    let tree = stackable(&stack, None, 0, HashSet::new(), 0, 129, 0.0, 0);
+    let tree = stackable(&stack);
     let _tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     // assert_eq!(result, tree_result);
     assert_eq!(result.len(), 2, "Bbox [1,0,0,1,0] - 2 results are within the bbox");


### PR DESCRIPTION
A couple of things in here:
- [x] merge StackableNode and StackableNodeCopy back together again
- [x] make `binned_stackable` be the recursive function and `stackable` be the wrapper function that does the binning, and sets all the tracking variables for recursion (the empty set, the zoom=0, etc.), so that now all the places that use stackable can just call `stackable(phrasematches)` and we don't have to change the call sites of like 150 coalesce fixtures every time we change the type signature of the recursive function
- [x] search-and-replace all the tests to just do the basic call
- [x] make the benchmark behavior match the upstream behavior (same sample size)