### PR TITLE
[wip] Constrained stackable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,6 +539,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2120,6 +2129,7 @@ dependencies = [
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+"checksum generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e40d0cee2e2fb4fba18b55a27bf96faf49fa86d49f178695bd3bf4500b156b4"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ordered-float = "1.0"
 failure = "0.1.5"
 smallvec = "0.6.10"
 rayon = "1.3.0"
+generational-arena = "0.2.7"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -25,14 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,13 +40,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -75,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -106,11 +103,13 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "min-max-heap 1.2.3-alpha.0 (git+https://github.com/apendleton/min-max-heap-rs.git?rev=1077ab489bbc0ecc994a14990746b76d635626b3)",
  "morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,7 +125,7 @@ name = "cc"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -139,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -168,33 +167,45 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.2.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.3.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.2.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -261,6 +272,14 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "generational-arena"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,8 +340,13 @@ name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
@@ -331,8 +355,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
-version = "0.2.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "min-max-heap"
@@ -393,11 +420,6 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
@@ -473,22 +495,23 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.0.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -561,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
-version = "0.3.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -750,9 +773,9 @@ dependencies = [
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
@@ -761,12 +784,13 @@ dependencies = [
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
-"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
-"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
@@ -775,6 +799,7 @@ dependencies = [
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e40d0cee2e2fb4fba18b55a27bf96faf49fa86d49f178695bd3bf4500b156b4"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1aec89c15e2cfa0f0eae8ca60e03cb10b30d25ea2c0ad7d6be60a95e32729994"
@@ -784,15 +809,15 @@ dependencies = [
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum librocksdb-sys 6.1.2 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum min-max-heap 1.2.3-alpha.0 (git+https://github.com/apendleton/min-max-heap-rs.git?rev=1077ab489bbc0ecc994a14990746b76d635626b3)" = "<none>"
 "checksum morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)" = "<none>"
 "checksum neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2e4dcd1e15c5944d89d283ec7c3b1b4ef83b5d2227b3b5d91d33224a45c7a3"
 "checksum neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "870c8f0b18ce83d8af6d95b9b723678aef55c047f29e09ac3e3d10ceecf57fd0"
 "checksum neon-runtime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff1178addfa03e060fc79e795c21170823e69f0229b0b13a4a2585190ef8fa76"
 "checksum neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "426deefc3718e89c8ee4528db5a8e71776f9326a387629b83b705ee2c1dae198"
-"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
@@ -803,8 +828,8 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
-"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
@@ -813,7 +838,7 @@ dependencies = [
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum rocksdb 0.12.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)" = "<none>"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
-"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-nmask-omit-1",
+  "version": "0.1.1-constrained-stackable-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -1,15 +1,18 @@
 #![allow(dead_code)]
 use std::borrow::Borrow;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 
 use crate::gridstore::common::*;
 use crate::gridstore::store::*;
 
+use generational_arena::{Arena, Index as ArenaIndex};
+use ordered_float::OrderedFloat;
+
 #[derive(Debug, Clone)]
 pub struct StackableNode<'a, T: Borrow<GridStore> + Clone + Debug> {
     pub phrasematch: Option<&'a PhrasematchSubquery<T>>,
-    pub children: Vec<StackableNode<'a, T>>,
+    pub children: Vec<ArenaIndex>,
     pub bmask: HashSet<u16>,
     pub mask: u32,
     pub idx: u16,
@@ -24,25 +27,117 @@ impl<'a, T: Borrow<GridStore> + Clone + Debug> StackableNode<'a, T> {
 }
 
 //tree traversal used only for tests
-pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(root: StackableNode<T>) -> Vec<StackableNode<T>> {
+pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(tree: StackableTree<T>) -> Vec<StackableNode<T>> {
     let mut node_vec: Vec<StackableNode<T>> = vec![];
     let mut stack: Vec<_> = vec![];
 
-    stack.push(root);
+    stack.push(tree.root.clone());
 
     while stack.len() > 0 {
         let node = stack.pop().unwrap();
         node_vec.push(node.clone());
-        for child in node.children {
-            stack.push(child);
+        for maybe_child in node.children {
+            if let Some(child) = tree.arena.get(maybe_child) {
+                stack.push(child.clone());
+            }
         }
     }
     return node_vec;
 }
 
+pub const LEAF_SOFT_MAX: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct ArenaManager<'a, T: Borrow<GridStore> + Clone + Debug> {
+    arena: Arena<StackableNode<'a, T>>,
+    // this is a map from max_relev to the count of leaves with that max_relev, and a list of all
+    // the arena indexes (leaf or otherwise) with that max_index
+    relev_map: HashMap<OrderedFloat<f64>, (usize, Vec<ArenaIndex>)>,
+    min_relev: OrderedFloat<f64>,
+    total_leaves: usize,
+    soft_max: usize
+}
+
+impl<'a, T: Borrow<GridStore> + Clone + Debug> ArenaManager<'a, T> {
+    fn new() -> Self {
+        ArenaManager {
+            arena: Arena::new(),
+            relev_map: HashMap::new(),
+            min_relev: OrderedFloat(std::f64::MAX),
+            total_leaves: 0,
+            soft_max: LEAF_SOFT_MAX,
+        }
+    }
+
+    fn add(&mut self, node: StackableNode<'a, T>) -> Option<ArenaIndex> {
+        let max_relev = OrderedFloat(node.max_relev);
+        let is_leaf = node.children.len() == 0;
+
+        if self.total_leaves >= self.soft_max && max_relev < self.min_relev {
+            // we're constrained, and this is worse than our worst, so don't keep it
+            None
+        } else {
+            // we're definitely going to add this
+            let arena_index = self.arena.insert(node);
+
+            let mut relev_entry = self.relev_map.entry(max_relev).or_insert((0, Vec::new()));
+
+            if is_leaf { relev_entry.0 += 1; }
+            relev_entry.1.push(arena_index);
+            self.total_leaves += 1;
+
+            if self.total_leaves < self.soft_max {
+                // this was an unconstrained add, so just update min if necessary and move on
+                if max_relev < self.min_relev {
+                    self.min_relev = max_relev;
+                }
+            } else {
+                // this was a constrained add. if we inserted into the min bucket, we're done,
+                // but if we added to some better bin than that, we may be able to cull the min
+                // bucket and choose a new min
+                if max_relev > self.min_relev {
+                    // if we're inserting into a bin other than the worst one, we might be able
+                    // to cull the worst one
+                    let min_count = self.relev_map.get(&self.min_relev).expect("must contain min_relev").0;
+                    let total_without_min = self.total_leaves - min_count;
+                    if total_without_min >= self.soft_max {
+                        // we can make due without the minimum bin
+                        self.cull_min();
+                    }
+                }
+            }
+            Some(arena_index)
+        }
+    }
+
+    fn cull_min(&mut self) {
+        if let Some((min_leaf_count, min_nodes)) = self.relev_map.remove(&self.min_relev) {
+            self.total_leaves -= min_leaf_count;
+            for node_index in min_nodes {
+                self.arena.remove(node_index);
+            }
+        }
+        // pick a new min
+        self.min_relev = self.relev_map.keys().min().map(|min| *min).unwrap_or(OrderedFloat(std::f64::MAX));
+    }
+
+    #[inline(always)]
+    pub fn get(&self, index: ArenaIndex) -> Option<&StackableNode<'a, T>> {
+        self.arena.get(index)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StackableTree<'a, T: Borrow<GridStore> + Clone + Debug> {
+    pub root: StackableNode<'a, T>,
+    pub arena: ArenaManager<'a, T>
+}
+
 pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
     phrasematches: &'a Vec<PhrasematchSubquery<T>>,
-) -> StackableNode<'a, T> {
+) -> StackableTree<'a, T> {
+    let mut arena: ArenaManager<'a, T> = ArenaManager::new();
+
     let mut binned_phrasematches: BTreeMap<u16, Vec<&'a PhrasematchSubquery<T>>> = BTreeMap::new();
     for phrasematch in phrasematches {
         binned_phrasematches
@@ -51,55 +146,74 @@ pub fn stackable<'a, T: Borrow<GridStore> + Clone + Debug>(
             .push(phrasematch);
     }
     let binned_phrasematches: Vec<_> = binned_phrasematches.into_iter().map(|(_k, v)| v).collect();
-    binned_stackable(&binned_phrasematches, None, HashSet::new(), 0, 129, 0.0, 0, 0)
+    let mut counters = (0, 0);
+    let root = binned_stackable(&binned_phrasematches, None, HashSet::new(), 0, 129, 0.0, 0, 0, &mut arena, &mut counters);
+    println!("{:?} {}", counters, arena.arena.len());
+    StackableTree { root, arena }
 }
 
 fn binned_stackable<'b, 'a: 'b, T: Borrow<GridStore> + Clone + Debug>(
-    binned_phrasematch: &'b Vec<Vec<&'a PhrasematchSubquery<T>>>,
-    phrasematch_result: Option<&'a PhrasematchSubquery<T>>,
+    binned_phrasematches: &'b Vec<Vec<&'a PhrasematchSubquery<T>>>,
+    current_phrasematch: Option<&'a PhrasematchSubquery<T>>,
     bmask: HashSet<u16>,
     mask: u32,
     idx: u16,
-    max_relev: f64,
+    relev_so_far: f64,
     zoom: u16,
     start_type_idx: usize,
+    arena: &mut ArenaManager<'a, T>,
+    counters: &mut (usize, usize),
 ) -> StackableNode<'a, T> {
     let mut node = StackableNode {
-        phrasematch: phrasematch_result,
+        phrasematch: current_phrasematch,
         children: vec![],
         mask: mask,
         bmask: bmask,
         idx: idx,
-        max_relev: max_relev,
+        max_relev: relev_so_far,
         zoom: zoom,
     };
 
-    for (type_idx, phrasematch_group) in binned_phrasematch.iter().enumerate().skip(start_type_idx)
+    for (type_idx, phrasematch_group) in binned_phrasematches.iter().enumerate().skip(start_type_idx)
     {
-        for phrasematches in phrasematch_group.iter() {
-            if (node.mask & phrasematches.mask) == 0
-                && phrasematches.non_overlapping_indexes.contains(&node.idx) == false
+        for phrasematch in phrasematch_group.iter() {
+            if (node.mask & phrasematch.mask) == 0
+                && phrasematch.non_overlapping_indexes.contains(&node.idx) == false
             {
-                let target_mask = &phrasematches.mask | node.mask;
+                let target_mask = &phrasematch.mask | node.mask;
                 let mut target_bmask: HashSet<u16> = node.bmask.iter().cloned().collect();
                 let phrasematch_bmask: HashSet<u16> =
-                    phrasematches.non_overlapping_indexes.iter().cloned().collect();
+                    phrasematch.non_overlapping_indexes.iter().cloned().collect();
                 target_bmask.extend(&phrasematch_bmask);
-                let target_relev = 0.0 + phrasematches.weight;
+                let target_relev = relev_so_far + phrasematch.weight;
 
-                node.children.push(binned_stackable(
-                    &binned_phrasematch,
-                    Some(&phrasematches),
+                let child_node = binned_stackable(
+                    &binned_phrasematches,
+                    Some(&phrasematch),
                     target_bmask,
                     target_mask,
-                    phrasematches.idx,
+                    phrasematch.idx,
                     target_relev,
-                    phrasematches.store.borrow().zoom,
+                    phrasematch.store.borrow().zoom,
                     type_idx + 1,
-                ));
+                    arena,
+                    counters
+                );
+
+                let max_relev = child_node.max_relev;
+
+                if let Some(arena_index) = arena.add(child_node) {
+                    node.children.push(arena_index);
+
+                    if max_relev > node.max_relev {
+                        node.max_relev = max_relev;
+                    }
+                }
             }
         }
     }
+    counters.0 += 1;
+    if node.children.len() == 0 { counters.1 += 1; }
     node
 }
 /*
@@ -168,25 +282,22 @@ mod test {
         let phrasematch_results = vec![a1, b1, b2];
 
         let tree = stackable(&phrasematch_results);
-        let a1_children_ids: Vec<u32> = tree.clone().children[0]
-            .clone()
+        let a1_children_ids: Vec<u32> = tree.arena.get(tree.root.children[0]).unwrap()
             .children
             .iter()
-            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .map(|node_idx| tree.arena.get(*node_idx).unwrap().phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
             .collect();
         assert_eq!(vec![1, 2], a1_children_ids, "a1 can stack with b1 and b2");
-        let b1_children_ids: Vec<u32> = tree.clone().children[1]
-            .clone()
+        let b1_children_ids: Vec<u32> = tree.arena.get(tree.root.children[1]).unwrap()
             .children
             .iter()
-            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .map(|node_idx| tree.arena.get(*node_idx).unwrap().phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
             .collect();
         assert_eq!(0, b1_children_ids.len(), "b1 cannot stack with b2, same nmask");
-        let b2_children_ids: Vec<u32> = tree.clone().children[2]
-            .clone()
+        let b2_children_ids: Vec<u32> = tree.arena.get(tree.root.children[2]).unwrap()
             .children
             .iter()
-            .map(|node| node.phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
+            .map(|node_idx| tree.arena.get(*node_idx).unwrap().phrasematch.as_ref().map(|p| p.match_keys[0].id).unwrap())
             .collect();
         assert_eq!(0, b2_children_ids.len(), "b2 cannot stack with b1, same nmask");
     }

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -182,6 +182,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "min-max-heap 1.2.3-alpha.0 (git+https://github.com/apendleton/min-max-heap-rs.git?rev=1077ab489bbc0ecc994a14990746b76d635626b3)",
@@ -472,6 +473,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1990,6 +1999,7 @@ dependencies = [
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+"checksum generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e40d0cee2e2fb4fba18b55a27bf96faf49fa86d49f178695bd3bf4500b156b4"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"


### PR DESCRIPTION
This branch alters stackable to add limits to the size of the tree that can be generated. Salient specifics:

## ArenaManager

All of the storage for nodes has now been moved to a [generational arena](https://docs.rs/generational-arena/0.2.7/generational_arena/). This makes it much easier to have both a reference to a node inside the tree itself, and a reference to a node in a tracking/priority structure elsewhere. More specifically, there's now a wrapper type `ArenaManager` that contains an arena and also that bookkeeping infrastructure.

The new process for adding a child to an existing node, rather than adding the StackableNode to the `children` vector directly, is to add it to the arena, which will return an ID, and add *that* to the child node. Additionally, because the arena manager is keeping track of the limits on the size of the arena, adding a new node might fail. In that case, it is skipped rather than being added to the child list.

The way the bookkeeping works is like this: we limit on the maximum number of *leaves* (not nodes), so we enter into a constrained/full state (where we're potentially deleting things or limiting what we insert) when the maximum number of leaves is exceeded. Each node that gets added to the arena gets added to the tracking structure, but only increments the leaf count if it's a leaf. All nodes are ranked by the maximum possible relevance that can be attained on their subtree, or in other words, the highest-relevance leaf descended from that node (*not*, to be extra clear, the weight of that node's phrasematch, or the accumulated relevance so far up to that point).

The tracking structure is a HashMap pretending to be a kind-of-sort-of priority queue. Essentially, every max_relevance currently associated with a living node has an entry in the HashMap, and it maps to a tuple of a count of leaves with that (max_)relevance (for leaves, relevance and max_relevance are the same), and a list of the indexes of all of the nodes, leaf or otherwise, that have that relevance. We also keep track of the lowest relevance of any entry in the table.

We have a soft-max limit on the total number of leaves in the structure, so if we're under that limit when we add a node, all we do is add the node's index to the node list for its relevance, increment the leaf count if it's a leaf, and maybe reduce the min_relevance if necessary. If we're at or above the limit, things get more interesting:
* if the node we're trying to add is below the limit, we fail to add it
* if the node is exactly at the limit, we just do a regular add even though we're at the limit -- if the new thing we're trying to add is tied with the worst thing we have, we don't have any way to decide which to keep and which to toss out, so we just keep them both and let ourselves exceed the limit
* if the node is above the limit, we do a regular add, and then consider the possibility that even without the worst bin, we might now be at our limit. If that's the case, we delete the entire worst bin and all of its nodes in their entirety (so no having to choose between them) and then loop over the keys to pick a new worst one.

## max_possible_relev

The other chunk of changes is that we now calculate some more stuff on the bins of phrasematches introduced in #82: rather than just being vectors, they're now vectors plus some metadata. There are two metadata items: the highest weight of any phrasematch of this type, and the sum of the highest per-type weights for each type after this one. In other words: for the `place` type, I'll know the highest-weight `place` phrasematch, and the sum of the highest-weight `postcode` phrasematch plus the highest-weight `address` phrasematch. What that second sum makes it possible to do is to interrogate: okay, if I'm working on a stack, and I've accumulated a country, a region, and a place so far, and I know the total of their actual weights, what's the best possible weight that I could ever produce by stacking more stuff onto it, assuming I hit a homerun and got the best possible postcode and address? Combined with the limiting from the first work chunk, we can say as we're working: "okay, we know the lowest relevance the arena is willing to accept right now; if there's no possible way even with the best possible stacking that recursing further from this point will ever produce nodes with a high enough relevance to make it into the arena, we can just not bother to recurse down this path at all."

The first chunk got us memory savings, but not really speed savings, because we still computed everything, but just didn't keep some of it. This allows us to avoid computing things in the first place that we were guaranteed to throw away (it's not perfect -- the max possible relevance is overly optimistic most of the time, so we still *may* end up computing and then throwing away some stuff, but hopefully less of it).

## Other odds and ends

* `max_relevance` in treeify_stacks doesn't do what we expected it to, apparently -- it isn't the highest reachable relevance from a given position, which was leading to weird ranking decisions. That has now been corrected in this branch
* one odd side effect of culling things after they've already been added to the tree is the possibility that something can get added and then deleted later without its parent also being deleted, meaning nodes can now have entries in their `children` list pointing to things that no longer exist. I considered doing fancier bookkeeping so that nodes know who their parents are and, upon deletion, can remove themselves from their parents' child list, but ugh that was such a hassle. It ended up being easier to just tweak coalesce to skip over any nodes it encounters that are no longer present.

## Still to do

- [ ] tests
- [ ] maybe some more optimizations available... I'm curious about using SmallVec or TinyVec for the children list now that it's just a list of indexes, and possibly also for the bins in the arena tracking map. But going to profile and see where that gets me