### PR TITLE
Use fixedbitset instead of hashset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -479,6 +480,11 @@ dependencies = [
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fixedbitset"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1640,6 +1646,7 @@ version = "0.1.0"
 dependencies = [
  "carmen-core 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4 1.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_s3 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2111,6 +2118,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4fcacf5cd3681968f6524ea159383132937739c6c40dabab9e37ed515911b"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ordered-float = "1.0"
 failure = "0.1.5"
 smallvec = "0.6.10"
 rayon = "1.3.0"
+fixedbitset = "0.3.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -48,6 +48,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "autocfg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "backtrace"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,11 +111,13 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "min-max-heap 1.2.3-alpha.0 (git+https://github.com/apendleton/min-max-heap-rs.git?rev=1077ab489bbc0ecc994a14990746b76d635626b3)",
  "morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,7 +133,7 @@ name = "cc"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -168,33 +175,45 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.2.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.3.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.2.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -246,6 +265,11 @@ dependencies = [
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fxhash"
@@ -325,14 +349,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
-version = "0.2.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "min-max-heap"
@@ -387,17 +419,13 @@ version = "0.1.0"
 dependencies = [
  "carmen-core 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
@@ -473,22 +501,23 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.0.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.4.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -561,7 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
-version = "0.3.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -750,9 +779,9 @@ dependencies = [
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
@@ -764,15 +793,17 @@ dependencies = [
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
-"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
-"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum cslice 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4fcacf5cd3681968f6524ea159383132937739c6c40dabab9e37ed515911b"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -784,15 +815,15 @@ dependencies = [
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum librocksdb-sys 6.1.2 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum min-max-heap 1.2.3-alpha.0 (git+https://github.com/apendleton/min-max-heap-rs.git?rev=1077ab489bbc0ecc994a14990746b76d635626b3)" = "<none>"
 "checksum morton 0.2.0 (git+https://github.com/apendleton/morton.git?rev=d892e8f2759aa2de29629232946db47924f1802e)" = "<none>"
 "checksum neon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2e4dcd1e15c5944d89d283ec7c3b1b4ef83b5d2227b3b5d91d33224a45c7a3"
 "checksum neon-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "870c8f0b18ce83d8af6d95b9b723678aef55c047f29e09ac3e3d10ceecf57fd0"
 "checksum neon-runtime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff1178addfa03e060fc79e795c21170823e69f0229b0b13a4a2585190ef8fa76"
 "checksum neon-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "426deefc3718e89c8ee4528db5a8e71776f9326a387629b83b705ee2c1dae198"
-"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-traits 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d9c79c952a4a139f44a0fe205c4ee66ce239c0e6ce72cd935f5f7e2f717549dd"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
@@ -803,8 +834,8 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
-"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
@@ -813,7 +844,7 @@ dependencies = [
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum rocksdb 0.12.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)" = "<none>"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
-"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -20,4 +20,5 @@ neon-serde = "0.1.1"
 serde = "1.*"
 failure = "0.1.5"
 owning_ref = "0.4"
+fixedbitset = "0.3.0"
 carmen-core = { path = "../" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -507,23 +507,11 @@ where
             }],
             mask: neon_serde::from_value(cx, mask)?,
             idx: neon_serde::from_value(cx, idx)?,
-            non_overlapping_indexes: vector_to_fixedbitset(non_overlapping_indexes),
+            non_overlapping_indexes: non_overlapping_indexes.into_iter().map(|n| n as usize).collect(),
         };
         phrasematches.push(subq);
     }
     Ok(phrasematches)
-}
-
-pub fn vector_to_fixedbitset(bitset: Vec<u32>) -> FixedBitSet {
-    let mut fbs = FixedBitSet::with_capacity(128);
-    for bit in bitset {
-        if bit == 1 {
-            fbs.insert(1);
-        } else {
-            fbs.insert(0);
-        }
-    }
-    return fbs;
 }
 
 pub fn js_stackable(mut cx: FunctionContext) -> JsResult<JsUndefined> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-constrained-stackable-1",
+  "version": "0.1.1-remove-hashsets-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -796,6 +796,7 @@ mod test {
     use super::*;
     use crate::gridstore::builder::*;
     use crate::gridstore::common::MatchPhrase::Range;
+    use fixedbitset::FixedBitSet;
 
     #[test]
     fn collapse_phrasematches_test() {
@@ -816,7 +817,7 @@ mod test {
         let a1 = PhrasematchSubquery {
             store: &store1,
             idx: 2,
-            non_overlapping_indexes: HashSet::new(),
+            non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             mask: 1,
             match_keys: vec![MatchKeyWithId {
@@ -828,7 +829,7 @@ mod test {
         let a2 = PhrasematchSubquery {
             store: &store1,
             idx: 2,
-            non_overlapping_indexes: HashSet::new(),
+            non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             mask: 1,
             match_keys: vec![MatchKeyWithId {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -1,11 +1,11 @@
 use core::cmp::{Ordering, Reverse};
 use std::borrow::Borrow;
-use std::collections::HashSet;
 
 use crate::gridstore::store::GridStore;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use failure::Error;
+use fixedbitset::FixedBitSet;
 use min_max_heap::MinMaxHeap;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
@@ -414,7 +414,8 @@ pub struct MatchKeyWithId {
 pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
     pub store: T,
     pub idx: u16,
-    pub non_overlapping_indexes: HashSet<u16>, // the field formerly known as bmask
+    #[serde(skip_serializing)]
+    pub non_overlapping_indexes: FixedBitSet, // the field formerly known as bmask
     pub weight: f64,
     pub mask: u32,
     pub match_keys: Vec<MatchKeyWithId>,

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -425,7 +425,7 @@ fn serialize_fixedbitset<S>(bits: &FixedBitSet, serializer: S) -> Result<S::Ok, 
 where
     S: Serializer,
 {
-    serializer.collect_seq(bits.as_slice().iter())
+    serializer.collect_seq(bits.ones())
 }
 
 pub struct ConstrainedPriorityQueue<T: Ord> {

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -8,7 +8,7 @@ use failure::Error;
 use fixedbitset::FixedBitSet;
 use min_max_heap::MinMaxHeap;
 use ordered_float::OrderedFloat;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 #[derive(Copy, Clone, Debug)]
 pub enum TypeMarker {
@@ -414,11 +414,18 @@ pub struct MatchKeyWithId {
 pub struct PhrasematchSubquery<T: Borrow<GridStore> + Clone> {
     pub store: T,
     pub idx: u16,
-    #[serde(skip_serializing)]
+    #[serde(serialize_with = "serialize_fixedbitset")]
     pub non_overlapping_indexes: FixedBitSet, // the field formerly known as bmask
     pub weight: f64,
     pub mask: u32,
     pub match_keys: Vec<MatchKeyWithId>,
+}
+
+fn serialize_fixedbitset<S>(bits: &FixedBitSet, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.collect_seq(bits.as_slice().iter())
 }
 
 pub struct ConstrainedPriorityQueue<T: Ord> {

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -15,8 +15,9 @@ pub use store::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fixedbitset::FixedBitSet;
     use once_cell::sync::Lazy;
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
 
     #[test]
     fn combined_test() {
@@ -644,7 +645,7 @@ mod tests {
             let subquery = PhrasematchSubquery {
                 store: reader,
                 idx: 1,
-                non_overlapping_indexes: HashSet::new(),
+                non_overlapping_indexes: FixedBitSet::with_capacity(128),
                 weight: 1.,
                 match_keys: vec![MatchKeyWithId {
                     id: 0,

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -91,9 +91,9 @@ fn binned_stackable<'b, 'a: 'b, T: Borrow<GridStore> + Clone + Debug>(
                 && phrasematches.non_overlapping_indexes.contains(node.idx as usize) == false
             {
                 let target_mask = &phrasematches.mask | node.mask;
-                let target_bmask: FixedBitSet = node.bmask.clone();
+                let mut target_bmask: FixedBitSet = node.bmask.clone();
                 let phrasematch_bmask: FixedBitSet = phrasematches.non_overlapping_indexes.clone();
-                target_bmask.intersection(&phrasematch_bmask);
+                target_bmask.union_with(&phrasematch_bmask);
                 let target_relev = 0.0 + phrasematches.weight;
 
                 node.children.push(binned_stackable(

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -6,9 +6,9 @@ use std::fmt::Debug;
 use crate::gridstore::common::*;
 use crate::gridstore::store::*;
 
+use fixedbitset::FixedBitSet;
 use generational_arena::{Arena, Index as ArenaIndex};
 use ordered_float::OrderedFloat;
-use fixedbitset::FixedBitSet;
 
 #[derive(Debug, Clone)]
 pub struct StackableNode<'a, T: Borrow<GridStore> + Clone + Debug> {

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0"
 failure = "0.1.5"
 rusoto_core = "0.40.0"
 rusoto_s3 = "0.40.0"
+fixedbitset = "0.3.0"
 
 [[bin]]
 name = "dump_store"

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -10,9 +10,9 @@ use lz4::Decoder;
 use rusoto_core::Region;
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use serde::{Deserialize, Serialize};
-
 use fixedbitset::FixedBitSet;
 use std::collections::{HashMap, HashSet};
+
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufWriter, Read, Write};
@@ -31,7 +31,7 @@ pub fn round(value: f64, digits: i32) -> f64 {
 pub fn langarray_to_langfield(array: &[u32]) -> u128 {
     let mut out = 0u128;
     for lang in array {
-        out = out | (1 << *lang) as u128;
+        out = out | (1 << *lang as usize);
     }
     out
 }
@@ -250,11 +250,8 @@ pub fn prepare_phrasematches(
                                 .unwrap();
                                 Arc::new(gs)
                             });
-                        let mut fbs: FixedBitSet = FixedBitSet::with_capacity(128);
+                        let fbs: FixedBitSet = placeholder.non_overlapping_indexes.clone().into_iter().map(|n| n as usize).collect();
 
-                        for x in placeholder.non_overlapping_indexes.clone() {
-                            fbs.insert(x as usize);
-                        }
                         PhrasematchSubquery {
                             store: store.clone(),
                             weight: placeholder.weight,
@@ -310,11 +307,7 @@ pub fn prepare_stackable_phrasematches(
                                 Arc::new(gs)
                             });
 
-                        let mut fbs: FixedBitSet = FixedBitSet::with_capacity(128);
-
-                        for x in placeholder.non_overlapping_indexes.clone() {
-                            fbs.insert(x as usize);
-                        }
+                        let fbs: FixedBitSet = placeholder.non_overlapping_indexes.clone().into_iter().map(|n| n as usize).collect();
 
                         PhrasematchSubquery {
                             store: store.clone(),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -6,11 +6,11 @@ extern crate serde_json;
 use carmen_core::gridstore::*;
 
 use failure::Error;
+use fixedbitset::FixedBitSet;
 use lz4::Decoder;
 use rusoto_core::Region;
 use rusoto_s3::{GetObjectRequest, S3Client, S3};
 use serde::{Deserialize, Serialize};
-use fixedbitset::FixedBitSet;
 use std::collections::{HashMap, HashSet};
 
 use std::env;
@@ -250,7 +250,12 @@ pub fn prepare_phrasematches(
                                 .unwrap();
                                 Arc::new(gs)
                             });
-                        let fbs: FixedBitSet = placeholder.non_overlapping_indexes.clone().into_iter().map(|n| n as usize).collect();
+                        let fbs: FixedBitSet = placeholder
+                            .non_overlapping_indexes
+                            .clone()
+                            .into_iter()
+                            .map(|n| n as usize)
+                            .collect();
 
                         PhrasematchSubquery {
                             store: store.clone(),
@@ -307,7 +312,12 @@ pub fn prepare_stackable_phrasematches(
                                 Arc::new(gs)
                             });
 
-                        let fbs: FixedBitSet = placeholder.non_overlapping_indexes.clone().into_iter().map(|n| n as usize).collect();
+                        let fbs: FixedBitSet = placeholder
+                            .non_overlapping_indexes
+                            .clone()
+                            .into_iter()
+                            .map(|n| n as usize)
+                            .collect();
 
                         PhrasematchSubquery {
                             store: store.clone(),

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -1,7 +1,7 @@
 use carmen_core::gridstore::*;
 use test_utils::*;
 
-use std::collections::HashSet;
+use fixedbitset::FixedBitSet;
 
 const ALL_LANGUAGES: u128 = u128::max_value();
 
@@ -26,7 +26,7 @@ fn coalesce_single_test_proximity_quadrants() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -126,7 +126,7 @@ fn coalesce_single_test_proximity_basic() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -177,7 +177,7 @@ fn coalesce_single_test_language_penalty() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -228,7 +228,7 @@ fn coalesce_multi_test_language_penalty() {
         1,
         14,
         1,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -244,7 +244,7 @@ fn coalesce_multi_test_language_penalty() {
         2,
         6,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -325,7 +325,7 @@ fn coalesce_single_test() {
         1,
         6,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         40.,
     );
     let subquery = PhrasematchSubquery {
@@ -579,7 +579,7 @@ fn coalesce_single_languages_test() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -623,7 +623,7 @@ fn coalesce_single_languages_test() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -667,7 +667,7 @@ fn coalesce_single_languages_test() {
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
-        non_overlapping_indexes: HashSet::new(),
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
             id: 0,
@@ -722,7 +722,7 @@ fn coalesce_multi_test() {
         0,
         1,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         40.,
     );
 
@@ -738,7 +738,7 @@ fn coalesce_multi_test() {
         1,
         2,
         1,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         40.,
     );
 
@@ -986,7 +986,7 @@ fn coalesce_multi_languages_test() {
         0,
         1,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -1021,7 +1021,7 @@ fn coalesce_multi_languages_test() {
         1,
         1,
         1,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -1218,7 +1218,7 @@ fn coalesce_multi_scoredist() {
         0,
         0,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -1234,7 +1234,7 @@ fn coalesce_multi_scoredist() {
         1,
         14,
         1,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -1313,7 +1313,7 @@ fn coalesce_multi_test_bbox() {
         0,
         1,
         0,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
     let store2 = create_store(
@@ -1327,7 +1327,7 @@ fn coalesce_multi_test_bbox() {
         1,
         2,
         1,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 
@@ -1342,7 +1342,7 @@ fn coalesce_multi_test_bbox() {
         2,
         5,
         2,
-        HashSet::new(),
+        FixedBitSet::with_capacity(128),
         200.,
     );
 


### PR DESCRIPTION
## Context
Through profiling we realised that we spend a lot of time hashing - it could be from using hashsets for bmasks or from using them in the priority queues used to manage stackable. This PR switches hashsets for fixedbitset in attempts to improve performance. Since, it is not deserializ-able via the auto derive, we've chosen instead to deserialise it to a vec<u32> and then create the fixedbitmask. 

cc @apendleton @CyanRook 