### PR TITLE
 Increase tree size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-treeify-stacks-maybe-like-12",
+  "version": "0.1.1-two-time",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -47,7 +47,7 @@ pub fn bfs<T: Borrow<GridStore> + Clone + Debug>(tree: StackableTree<T>) -> Vec<
     return node_vec;
 }
 
-pub const LEAF_SOFT_MAX: usize = 1024;
+pub const LEAF_SOFT_MAX: usize = 2000;
 
 #[derive(Debug, Clone)]
 pub struct ArenaManager<'a, T: Borrow<GridStore> + Clone + Debug> {


### PR DESCRIPTION
### Context 

In order to make sure that we don't have trees with 100k edges, we ended up adding limits which landed in #85 PR. We ran into a case while triaging quality drops where the result that we wanted was just outside of the limit of the tree. We ran some benches and did a quality check to see what the implications of doubling the tree size would look like. Here are the results from running benches against current `treeify-stacks` and this branch: 

Tree size: 2000
```
test result: ok. 0 passed; 0 failed; 31 ignored; 0 measured; 0 filtered out

     Running target/release/deps/benchmarks-1e18997c4c22dffb
Gnuplot not found, disabling plotting
Benchmarking coalesce_global: Collecting 20 samples in estimated 10.392 s (210 iterat                                                                                     coalesce_global         time:   [5.4559 ms 5.7280 ms 6.1611 ms]
                        change: [-12.960% +2.4107% +21.229%] (p = 0.79 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild

Benchmarking coalesce_prox: Collecting 20 samples in estimated 10.489 s (210 iteratio                                                                                     coalesce_prox           time:   [6.2387 ms 6.5100 ms 6.9595 ms]
                        change: [-15.017% -0.5450% +15.699%] (p = 0.95 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild

Benchmarking coalesce_ac_global: Collecting 20 samples in estimated 10.121 s (210 ite                                                                                     coalesce_ac_global      time:   [3.7725 ms 4.5375 ms 5.0419 ms]
                        change: [-33.906% -1.9784% +42.140%] (p = 0.92 > 0.05)
                        No change in performance detected.

Benchmarking coalesce_ac_prox: Collecting 20 samples in estimated 26.644 s (210 itera                                                                                     coalesce_ac_prox        time:   [50.520 ms 54.269 ms 59.340 ms]
                        change: [-8.0111% -1.1004% +6.5976%] (p = 0.77 > 0.05)
                        No change in performance detected.
Found 3 outliers among 20 measurements (15.00%)
  3 (15.00%) low mild

Benchmarking stackable_us_address: Collecting 20 samples in estimated 743.15 s (210 i                                                                                     stackable_us_address    time:   [751.82 us 820.43 us 861.74 us]
                        change: [-11.085% +14.945% +48.970%] (p = 0.31 > 0.05)
                        No change in performance detected.

Benchmarking stackable_us_address_postcode: Collecting 20 samples in estimated 751.34                                                                                     stackable_us_address_postcode
                        time:   [488.33 us 510.22 us 525.84 us]
                        change: [-11.262% +11.256% +42.090%] (p = 0.40 > 0.05)
                        No change in performance detected.

Benchmarking stackable_us-address_postcode_place_region: Collecting 20 samples in est                                                                                     stackable_us-address_postcode_place_region
                        time:   [1.7912 ms 1.9105 ms 1.9819 ms]
                        change: [-0.0809% +22.664% +50.953%] (p = 0.07 > 0.05)
                        No change in performance detected.

Gnuplot not found, disabling plotting
     Running target/release/deps/prod_data-c67c98b3a0b00905

running 0 tests
```

Tree size: 1024

```
test result: ok. 0 passed; 0 failed; 31 ignored; 0 measured; 0 filtered out

     Running target/release/deps/benchmarks-1e18997c4c22dffb
Gnuplot not found, disabling plotting
coalesce_global         time:   [5.4315 ms 5.7428 ms 6.2268 ms]
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild

coalesce_prox           time:   [6.3082 ms 6.5953 ms 7.0389 ms]
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low severe

coalesce_ac_global      time:   [3.8294 ms 4.6315 ms 5.1742 ms]

Benchmarking coalesce_ac_prox: Collecting 20 samples in estimated 27.127 s (210 itera                                                                                     coalesce_ac_prox        time:   [52.429 ms 55.537 ms 60.110 ms]

Benchmarking stackable_us_address: Collecting 20 samples in estimated 10.101 s (210 i                                                                                     stackable_us_address    time:   [652.50 us 705.81 us 738.61 us]

Benchmarking stackable_us_address_postcode: Collecting 20 samples in estimated 45.060                                                                                     stackable_us_address_postcode
                        time:   [438.52 us 458.06 us 471.56 us]

Benchmarking stackable_us-address_postcode_place_region: Collecting 20 samples in est                                                                                     stackable_us-address_postcode_place_region
                        time:   [1.4566 ms 1.5455 ms 1.5963 ms]

Gnuplot not found, disabling plotting
     Running target/release/deps/prod_data-c67c98b3a0b00905
```

Given that aren't any performance implications from doubling the size of the tree and the fact that it has a positive effect on the passrates - we're moving ahead with doubling the size of the tree. 

cc @apendleton @CyanRook 