### PR TITLE
Allow phrasematches to be constrained to only nearby results

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -494,6 +494,13 @@ where
 
         let idx = js_phrasematch.get(cx, "idx")?;
 
+        let js_nearby_only = js_phrasematch.get(cx, "nearby_only")?;
+        let nearby_only: bool = if let Ok(_) = js_nearby_only.downcast::<JsUndefined>() {
+            false
+        } else {
+            js_nearby_only.downcast::<JsBoolean>().or_throw(cx)?.value()
+        };
+
         let js_non_overlapping_indexes = js_phrasematch.get(cx, "non_overlapping_indexes")?;
         let non_overlapping_indexes: Vec<u32> = neon_serde::from_value(cx, js_non_overlapping_indexes)?;
 
@@ -503,6 +510,7 @@ where
             match_keys: vec![MatchKeyWithId {
                 key: MatchKey { match_phrase: neon_serde::from_value(cx, match_phrase)?, lang_set },
                 id: neon_serde::from_value(cx, id)?,
+                nearby_only
             }],
             mask: neon_serde::from_value(cx, mask)?,
             idx: neon_serde::from_value(cx, idx)?,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-treeify-stacks-maybe-like-12",
+  "version": "0.1.1-nearby-only-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-nearby-only-1",
+  "version": "0.1.1-nearby-only-2",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -825,6 +825,7 @@ mod test {
             weight: 0.5,
             mask: 1,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 1,
             }],
@@ -837,6 +838,7 @@ mod test {
             weight: 0.5,
             mask: 1,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 2,
             }],

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -449,11 +449,17 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
 
                 for key_group in subquery.match_keys.iter() {
                     if is_single || !data_cache.contains_key(&key_group.id) {
+                        let match_opts = if key_group.nearby_only {
+                            step.match_opts.with_nearby_only()
+                        } else {
+                            step.match_opts.clone()
+                        };
+
                         keys.entry((key_group.id, is_single)).or_insert_with(|| KeyFetchStep {
                             key_id: key_group.id,
                             subquery: (*subquery).clone(),
                             key: key_group.key.clone(),
-                            match_opts: step.match_opts.clone(),
+                            match_opts: match_opts,
                             is_single,
                         });
                     }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -203,8 +203,6 @@ impl MatchOpts {
                 std::cmp::min(old_box[2], new_box[2]),
                 std::cmp::min(old_box[3], new_box[3]),
             ]
-        } else {
-            println!("{:?} {:?}", prox, new_box);
         }
 
         constrained.bbox = Some(new_box);
@@ -352,6 +350,36 @@ mod tests {
             MATCH_OPTS_BBOX.5.adjust_to_zoom(4).bbox.unwrap(),
             [3, 1, 4, 2],
             "Multi-tile parent zoomed in one zoom level includes all the higher-zoom tiles"
+        );
+    }
+
+    #[test]
+    fn nearby_only() {
+        let opts = matchopts_proximity_generator([100, 100], 14);
+        assert_eq!(
+            opts.with_nearby_only(),
+            MatchOpts { bbox: Some([83, 83, 117, 117]), proximity: Some([100, 100]), zoom: 14 }
+        );
+
+        let opts = matchopts_proximity_generator([100, 100], 6);
+        assert_eq!(
+            opts.with_nearby_only(),
+            MatchOpts { bbox: Some([99, 99, 101, 101]), proximity: Some([100, 100]), zoom: 6 }
+        );
+
+        // truncate at the antemeridian
+        let opts = matchopts_proximity_generator([5, 5], 14);
+        assert_eq!(
+            opts.with_nearby_only(),
+            MatchOpts { bbox: Some([0, 0, 22, 22]), proximity: Some([5, 5]), zoom: 14 }
+        );
+
+        // test interaction between existing bbox and limiter
+        let mut opts = matchopts_proximity_generator([100, 100], 14);
+        opts.bbox = Some([90, 70, 115, 180]);
+        assert_eq!(
+            opts.with_nearby_only(),
+            MatchOpts { bbox: Some([90, 83, 115, 117]), proximity: Some([100, 100]), zoom: 14 }
         );
     }
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -443,6 +443,7 @@ impl Eq for CoalesceContext {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MatchKeyWithId {
     pub key: MatchKey,
+    #[serde(default)]
     pub nearby_only: bool,
     pub id: u32,
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -407,6 +407,7 @@ impl Eq for CoalesceContext {}
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MatchKeyWithId {
     pub key: MatchKey,
+    pub nearby_only: bool,
     pub id: u32,
 }
 

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -648,6 +648,7 @@ mod tests {
                 non_overlapping_indexes: FixedBitSet::with_capacity(128),
                 weight: 1.,
                 match_keys: vec![MatchKeyWithId {
+                    nearby_only: false,
                     id: 0,
                     key: MatchKey {
                         match_phrase: MatchPhrase::Range { start: range.0, end: range.1 },

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -296,6 +296,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 0,
             }],
@@ -308,6 +309,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 1,
             }],
@@ -320,6 +322,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 2,
             }],
@@ -410,6 +413,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 0,
             }],
@@ -422,6 +426,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 1,
             }],
@@ -457,6 +462,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 0,
             }],
@@ -469,6 +475,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 1,
             }],
@@ -503,6 +510,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 0,
             }],
@@ -515,6 +523,7 @@ mod test {
             non_overlapping_indexes: FixedBitSet::with_capacity(128),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 key: MatchKey { match_phrase: Range { start: 0, end: 1 }, lang_set: 0 },
                 id: 1,
             }],

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -29,6 +29,7 @@ fn coalesce_single_test_proximity_quadrants() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         }],
@@ -129,6 +130,7 @@ fn coalesce_single_test_proximity_basic() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         }],
@@ -180,6 +182,7 @@ fn coalesce_single_test_language_penalty() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 2 },
         }],
@@ -257,6 +260,7 @@ fn coalesce_multi_test_language_penalty() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -271,6 +275,7 @@ fn coalesce_multi_test_language_penalty() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -334,6 +339,7 @@ fn coalesce_single_test() {
         non_overlapping_indexes: store.non_overlapping_indexes.clone(),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
         }],
@@ -582,6 +588,7 @@ fn coalesce_single_languages_test() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -626,6 +633,7 @@ fn coalesce_single_languages_test() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -670,6 +678,7 @@ fn coalesce_single_languages_test() {
         non_overlapping_indexes: FixedBitSet::with_capacity(128),
         weight: 1.,
         match_keys: vec![MatchKeyWithId {
+            nearby_only: false,
             id: 0,
             key: MatchKey {
                 match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -749,6 +758,7 @@ fn coalesce_multi_test() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -763,6 +773,7 @@ fn coalesce_multi_test() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1034,6 +1045,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1048,6 +1060,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1092,6 +1105,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1106,6 +1120,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1150,6 +1165,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1164,6 +1180,7 @@ fn coalesce_multi_languages_test() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1245,6 +1262,7 @@ fn coalesce_multi_scoredist() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1259,6 +1277,7 @@ fn coalesce_multi_scoredist() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1353,6 +1372,7 @@ fn coalesce_multi_test_bbox() {
             non_overlapping_indexes: store1.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1367,6 +1387,7 @@ fn coalesce_multi_test_bbox() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 3 },
@@ -1441,6 +1462,7 @@ fn coalesce_multi_test_bbox() {
             non_overlapping_indexes: store2.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 0,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 4 },
@@ -1455,6 +1477,7 @@ fn coalesce_multi_test_bbox() {
             non_overlapping_indexes: store3.non_overlapping_indexes.clone(),
             weight: 0.5,
             match_keys: vec![MatchKeyWithId {
+                nearby_only: false,
                 id: 1,
                 key: MatchKey {
                     match_phrase: MatchPhrase::Range { start: 1, end: 4 },

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -717,6 +717,49 @@ fn coalesce_single_languages_test() {
 }
 
 #[test]
+fn coalesce_single_nearby_only() {
+    let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
+    let mut builder = GridStoreBuilder::new(directory.path()).unwrap();
+
+    let key = GridKey { phrase_id: 1, lang_set: 1 };
+
+    let entries = vec![
+        GridEntry { id: 1, x: 100, y: 100, relev: 1., score: 1, source_phrase_hash: 0 },
+        GridEntry { id: 2, x: 50, y: 50, relev: 1., score: 1, source_phrase_hash: 0 },
+        GridEntry { id: 3, x: 90, y: 90, relev: 1., score: 1, source_phrase_hash: 0 },
+        GridEntry { id: 4, x: 200, y: 200, relev: 1., score: 1, source_phrase_hash: 0 },
+    ];
+    builder.insert(&key, entries).expect("Unable to insert record");
+
+    builder.finish().unwrap();
+
+    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+    let subquery = PhrasematchSubquery {
+        store: &store,
+        idx: 1,
+        non_overlapping_indexes: FixedBitSet::with_capacity(128),
+        weight: 1.,
+        match_keys: vec![MatchKeyWithId {
+            nearby_only: true,
+            id: 0,
+            key: MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 3 }, lang_set: 1 },
+        }],
+        mask: 1 << 0,
+    };
+    let stack = vec![subquery];
+    let match_opts = MatchOpts { zoom: 14, proximity: Some([100, 100]), ..MatchOpts::default() };
+    let tree = stackable(&stack);
+    let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
+    let result_ids: Vec<u32> =
+        tree_result.iter().map(|context| context.entries[0].grid_entry.id).collect();
+    assert_eq!(
+        result_ids,
+        [1, 3],
+        "Results with the same relev and score should be ordered by distance"
+    );
+}
+
+#[test]
 fn coalesce_multi_test() {
     // Add more specific layer into a store
     let store1 = create_store(


### PR DESCRIPTION
This branch introduces a new attribute on phrasematches, `nearby_only`, which allows Carmen to communicate that a phrasematch is likely to be expensive to query globally, and to only allow results that are close to the proximity point for that match.

On the Rust side, we currently have a hard-coded search radius for these phrasematches (25 miles), and calculate the number of tiles at that phrasematch's index's zoom level necessary to cover that radius, then calculate a bounding box by padding out the proximity point by that number of tiles in all directions (hard-stopping on the min side at 0 -- this is not antemeridian-crossing, but oh well). If the query already has a bbox, we intersect our newly generated bbox with the supplied one (so, only use the area covered by both).

Things that still need to happen:
- [x] add tests
- [x] fix the benchmarks -- because of this new field, they're currently all broken because none of our bench data includes it; I think I can tweak the benchmarks for which proximity doesn't matter to just assume the property is false (so that's all the stackable ones, and the non-prox coalesce ones), but will need to regenerate the data for the with-prox coalesce tests