### PR TITLE
Bbox aware coalesce

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -81,6 +81,7 @@ struct GridStoreOpts {
     pub zoom: u16,
     pub type_id: u16,
     pub coalesce_radius: f64,
+    pub bbox: [u16; 4],
 }
 
 declare_types! {
@@ -286,7 +287,8 @@ declare_types! {
                         filename,
                         opts.zoom,
                         opts.type_id,
-                        opts.coalesce_radius
+                        opts.coalesce_radius,
+                        opts.bbox,
                     )
                 },
                 None => GridStore::new(filename)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-nearby-only-3",
+  "version": "0.1.1-bbox-aware-coalesce-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-bbox-aware-coalesce-1",
+  "version": "0.1.1-bbox-aware-coalesce-3",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -675,7 +675,6 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
                                     adjust_bbox_zoom(state_bbox, current_zoom, child_zoom)
                                 };
                                 let child_bbox = child.phrasematch.unwrap().store.borrow().bbox;
-                                //println!("{:?} {:?} {:?}", child_bbox, zoomed_bbox, bboxes_intersect(child_bbox, zoomed_bbox));
                                 if !bboxes_intersect(child_bbox, zoomed_bbox) {
                                     continue;
                                 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -114,6 +114,36 @@ impl Default for MatchOpts {
 pub const EARTH_CIRC_IN_MILES: f64 = 24901.0;
 pub const NEARBY_RADIUS: f64 = 25.0;
 
+#[inline(always)]
+pub fn adjust_bbox_zoom(bbox: [u16; 4], source_z: u16, target_z: u16) -> [u16; 4] {
+    if target_z < source_z {
+        let zoom_levels = source_z - target_z;
+        // If this is a zoom out, divide each coordinate by 2^(number of zoom levels).
+        // This is the same as shifting bits to the right by the number of zoom levels.
+        [
+            bbox[0] >> zoom_levels,
+            bbox[1] >> zoom_levels,
+            bbox[2] >> zoom_levels,
+            bbox[3] >> zoom_levels,
+        ]
+    } else {
+        // If this is a zoom in
+        let scale_multiplier = 1 << (target_z - source_z);
+
+        // Scale the top left (min x and y) tile coordinates by 2^(zoom diff).
+        // Scale the bottom right (max x and y) tile coordinates by 2^(zoom diff),
+        // and add the new number of tiles (-1) to get the outer edge of possible tiles.
+        // We subtract 1 from the scale_multiplier before adding to prevent an integer overflow
+        // given that we're using a 16bit integer
+        [
+            bbox[0] * scale_multiplier,
+            bbox[1] * scale_multiplier,
+            bbox[2] * scale_multiplier + (scale_multiplier - 1),
+            bbox[3] * scale_multiplier + (scale_multiplier - 1),
+        ]
+    }
+}
+
 impl MatchOpts {
     pub fn adjust_to_zoom(&self, target_z: u16) -> MatchOpts {
         if self.zoom == target_z {
@@ -142,37 +172,7 @@ impl MatchOpts {
                 None => None,
             };
 
-            let adjusted_bbox = match &self.bbox {
-                Some(orig_bbox) => {
-                    if target_z < self.zoom {
-                        let zoom_levels = self.zoom - target_z;
-                        // If this is a zoom out, divide each coordinate by 2^(number of zoom levels).
-                        // This is the same as shifting bits to the right by the number of zoom levels.
-                        Some([
-                            orig_bbox[0] >> zoom_levels,
-                            orig_bbox[1] >> zoom_levels,
-                            orig_bbox[2] >> zoom_levels,
-                            orig_bbox[3] >> zoom_levels,
-                        ])
-                    } else {
-                        // If this is a zoom in
-                        let scale_multiplier = 1 << (target_z - self.zoom);
-
-                        // Scale the top left (min x and y) tile coordinates by 2^(zoom diff).
-                        // Scale the bottom right (max x and y) tile coordinates by 2^(zoom diff),
-                        // and add the new number of tiles (-1) to get the outer edge of possible tiles.
-                        // We subtract 1 from the scale_multiplier before adding to prevent an integer overflow
-                        // given that we're using a 16bit integer
-                        Some([
-                            orig_bbox[0] * scale_multiplier,
-                            orig_bbox[1] * scale_multiplier,
-                            orig_bbox[2] * scale_multiplier + (scale_multiplier - 1),
-                            orig_bbox[3] * scale_multiplier + (scale_multiplier - 1),
-                        ])
-                    }
-                }
-                None => None,
-            };
+            let adjusted_bbox = self.bbox.map(|bbox| adjust_bbox_zoom(bbox, self.zoom, target_z));
 
             MatchOpts { zoom: target_z, proximity: adjusted_proximity, bbox: adjusted_bbox }
         }

--- a/rust-src/src/gridstore/mod.rs
+++ b/rust-src/src/gridstore/mod.rs
@@ -9,6 +9,7 @@ mod store;
 pub use builder::*;
 pub use coalesce::{coalesce, collapse_phrasematches, stack_and_coalesce, tree_coalesce};
 pub use common::*;
+pub use spatial::global_bbox_for_zoom;
 pub use stackable::stackable;
 pub use store::*;
 
@@ -194,7 +195,9 @@ mod tests {
 
         builder.finish().unwrap();
 
-        let reader = GridStore::new_with_options(directory.path(), 14, 0, 1000.).unwrap();
+        let reader =
+            GridStore::new_with_options(directory.path(), 14, 0, 1000., global_bbox_for_zoom(14))
+                .unwrap();
 
         let search_key =
             MatchKey { match_phrase: MatchPhrase::Range { start: 1, end: 2 }, lang_set: 1 };
@@ -507,10 +510,22 @@ mod tests {
         builder_with_boundaries.finish().unwrap();
         builder_without_boundaries.finish().unwrap();
 
-        let reader_with_boundaries =
-            GridStore::new_with_options(directory_with_boundaries.path(), 14, 0, 200.).unwrap();
-        let reader_without_boundaries =
-            GridStore::new_with_options(directory_without_boundaries.path(), 14, 0, 200.).unwrap();
+        let reader_with_boundaries = GridStore::new_with_options(
+            directory_with_boundaries.path(),
+            14,
+            0,
+            200.,
+            global_bbox_for_zoom(14),
+        )
+        .unwrap();
+        let reader_without_boundaries = GridStore::new_with_options(
+            directory_without_boundaries.path(),
+            14,
+            0,
+            200.,
+            global_bbox_for_zoom(14),
+        )
+        .unwrap();
 
         (
             reader_with_boundaries,

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -598,6 +598,10 @@ pub fn scoredist(mut zoom: u16, mut distance: f64, mut score: u8, radius: f64) -
     ((6. * E_POW[score as usize] / E_POW[7]) + 1.) / dist_ratio
 }
 
+pub fn bboxes_intersect(bbox1: [u16; 4], bbox2: [u16; 4]) -> bool {
+    !(bbox1[0] > bbox2[2] || bbox1[2] < bbox2[0] || bbox1[1] > bbox2[3] || bbox1[3] < bbox2[1])
+}
+
 #[test]
 fn scoredist_test() {
     assert_eq!(scoredist(14, 1., 0, 400.), 321.7508133738646, "scoredist for a feature 1 tile away from proximity point with score 0 and radius 400 should be 321.7508133738646");

--- a/rust-src/src/gridstore/spatial.rs
+++ b/rust-src/src/gridstore/spatial.rs
@@ -602,6 +602,43 @@ pub fn bboxes_intersect(bbox1: [u16; 4], bbox2: [u16; 4]) -> bool {
     !(bbox1[0] > bbox2[2] || bbox1[2] < bbox2[0] || bbox1[1] > bbox2[3] || bbox1[3] < bbox2[1])
 }
 
+#[inline(always)]
+pub fn adjust_bbox_zoom(bbox: [u16; 4], source_z: u16, target_z: u16) -> [u16; 4] {
+    if target_z < source_z {
+        let zoom_levels = source_z - target_z;
+        // If this is a zoom out, divide each coordinate by 2^(number of zoom levels).
+        // This is the same as shifting bits to the right by the number of zoom levels.
+        [
+            bbox[0] >> zoom_levels,
+            bbox[1] >> zoom_levels,
+            bbox[2] >> zoom_levels,
+            bbox[3] >> zoom_levels,
+        ]
+    } else {
+        // If this is a zoom in
+        let scale_multiplier = 1 << (target_z - source_z);
+
+        // Scale the top left (min x and y) tile coordinates by 2^(zoom diff).
+        // Scale the bottom right (max x and y) tile coordinates by 2^(zoom diff),
+        // and add the new number of tiles (-1) to get the outer edge of possible tiles.
+        // We subtract 1 from the scale_multiplier before adding to prevent an integer overflow
+        // given that we're using a 16bit integer
+        [
+            bbox[0] * scale_multiplier,
+            bbox[1] * scale_multiplier,
+            bbox[2] * scale_multiplier + (scale_multiplier - 1),
+            bbox[3] * scale_multiplier + (scale_multiplier - 1),
+        ]
+    }
+}
+
+pub fn global_bbox_for_zoom(zoom: u16) -> [u16; 4] {
+    // do this at u32 to avoid overflow at z16
+    let max: u32 = (1u32 << zoom) - 1;
+    let max = max as u16;
+    [0, 0, max, max]
+}
+
 #[test]
 fn scoredist_test() {
     assert_eq!(scoredist(14, 1., 0, 400.), 321.7508133738646, "scoredist for a feature 1 tile away from proximity point with score 0 and radius 400 should be 321.7508133738646");

--- a/rust-src/src/gridstore/stackable.rs
+++ b/rust-src/src/gridstore/stackable.rs
@@ -272,6 +272,7 @@ mod test {
     use super::*;
     use crate::gridstore::builder::*;
     use crate::gridstore::common::MatchPhrase::Range;
+    use crate::gridstore::spatial::global_bbox_for_zoom;
 
     #[test]
     fn simple_stackable_test() {
@@ -287,8 +288,12 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store1 = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
-        let store2 = GridStore::new_with_options(directory.path(), 14, 2, 200.).unwrap();
+        let store1 =
+            GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+                .unwrap();
+        let store2 =
+            GridStore::new_with_options(directory.path(), 14, 2, 200., global_bbox_for_zoom(14))
+                .unwrap();
 
         let a1 = PhrasematchSubquery {
             store: &store1,
@@ -399,7 +404,9 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+        let store =
+            GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+                .unwrap();
         let mut a1_bmask: FixedBitSet = FixedBitSet::with_capacity(128);
         a1_bmask.insert(0);
         a1_bmask.insert(1);
@@ -454,7 +461,9 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+        let store =
+            GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+                .unwrap();
 
         let a1 = PhrasematchSubquery {
             store: &store,
@@ -502,7 +511,9 @@ mod test {
         ];
         builder.insert(&key, entries).expect("Unable to insert record");
         builder.finish().unwrap();
-        let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+        let store =
+            GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+                .unwrap();
 
         let a1 = PhrasematchSubquery {
             store: &store,

--- a/rust-src/src/gridstore/store.rs
+++ b/rust-src/src/gridstore/store.rs
@@ -27,6 +27,7 @@ pub struct GridStore {
     pub zoom: u16,
     pub type_id: u16,
     pub coalesce_radius: f64,
+    pub bbox: [u16; 4],
 }
 
 #[inline]
@@ -252,7 +253,7 @@ impl<T: Iterator<Item = MatchEntry>> Eq for QueueElement<T> {}
 
 impl GridStore {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        GridStore::new_with_options(path, 6, 0, 0.0)
+        GridStore::new_with_options(path, 6, 0, 0.0, [0, 0, 63, 63])
     }
 
     pub fn new_with_options<P: AsRef<Path>>(
@@ -260,6 +261,7 @@ impl GridStore {
         zoom: u16,
         type_id: u16,
         coalesce_radius: f64,
+        bbox: [u16; 4],
     ) -> Result<Self, Error> {
         let path = path.as_ref().to_owned();
         let mut opts = Options::default();
@@ -284,7 +286,7 @@ impl GridStore {
             None => HashSet::new(),
         };
 
-        Ok(GridStore { db, path, bin_boundaries, zoom, type_id, coalesce_radius })
+        Ok(GridStore { db, path, bin_boundaries, zoom, type_id, coalesce_radius, bbox })
     }
 
     #[inline(never)]

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -74,8 +74,14 @@ pub fn create_store(
     }
     builder.finish().unwrap();
     TestStore {
-        store: GridStore::new_with_options(directory.path(), zoom, type_id, coalesce_radius)
-            .unwrap(),
+        store: GridStore::new_with_options(
+            directory.path(),
+            zoom,
+            type_id,
+            coalesce_radius,
+            global_bbox_for_zoom(zoom),
+        )
+        .unwrap(),
         idx,
         non_overlapping_indexes,
     }
@@ -246,6 +252,7 @@ pub fn prepare_phrasematches(
                                     placeholder.store.zoom,
                                     placeholder.store.type_id,
                                     placeholder.store.coalesce_radius,
+                                    global_bbox_for_zoom(placeholder.store.zoom),
                                 )
                                 .unwrap();
                                 Arc::new(gs)
@@ -307,6 +314,7 @@ pub fn prepare_stackable_phrasematches(
                                     placeholder.store.zoom,
                                     placeholder.store.type_id,
                                     placeholder.store.coalesce_radius,
+                                    global_bbox_for_zoom(placeholder.store.zoom),
                                 )
                                 .unwrap();
                                 Arc::new(gs)

--- a/tests/bindings/test.js
+++ b/tests/bindings/test.js
@@ -227,7 +227,7 @@ tape('Coalesce single valid stack - Valid inputs', (t) => {
         ]
     );
     builder.finish();
-    const readerOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+    const readerOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200, bbox: globalBboxForZoom(14) };
 	const reader = new addon.GridStore(tmpDir.name, readerOpts);
 
     const valid_stack = [{
@@ -277,7 +277,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder1.finish();
-    const reader1Opts = { idx: 0, zoom: 1, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+    const reader1Opts = { idx: 0, zoom: 1, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200, bbox: globalBboxForZoom(1) };
 	const reader1 = new addon.GridStore(tmpDir1.name, reader1Opts);
 
     const tmpDir2 = tmp.dirSync();
@@ -289,7 +289,7 @@ tape('Coalesce multi valid stack - Valid inputs', (t) => {
         ]
     );
     builder2.finish();
-    const reader2Opts = { idx: 1, zoom: 2, non_overlapping_indexes: Array.from(new Set()), type_id: 1, coalesce_radius: 200 };
+    const reader2Opts = { idx: 1, zoom: 2, non_overlapping_indexes: Array.from(new Set()), type_id: 1, coalesce_radius: 200, bbox: globalBboxForZoom(2) };
 	const reader2 = new addon.GridStore(tmpDir2.name, reader2Opts);
 
     const valid_coalesce_multi = [{
@@ -424,9 +424,9 @@ tape('Bin boundaries', (t) => {
     builderWithBoundaries.finish();
     builderWithoutBoundaries.finish();
 
-    const readerWithBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+    const readerWithBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200, bbox: globalBboxForZoom(14) };
 	const readerWithBoundaries = new addon.GridStore(directoryWithBoundaries.name, readerWithBoundariesOpts);
-    const readerWithoutBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+    const readerWithoutBoundariesOpts = { idx: 1, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200, bbox: globalBboxForZoom(14) };
 	const readerWithoutBoundaries = new addon.GridStore(directoryWithoutBoundaries.name, readerWithoutBoundariesOpts);
 
     const findRange = (prefix) => {
@@ -486,7 +486,7 @@ tape('Deserialize phrasematch results', (t) => {
         ]
     );
     builder.finish();
-    const storeOpts = { idx: 0, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200 };
+    const storeOpts = { idx: 0, zoom: 14, non_overlapping_indexes: Array.from(new Set()), type_id: 0, coalesce_radius: 200, bbox: globalBboxForZoom(14) };
 	const store = new addon.GridStore(tmpDir.name, storeOpts);
     let phrasematchResults = [
         new Phrasematch(store, ['main', 'street'], 'main street', 1, [0, 2], 1, 0, 14, 6, 1, false, false, false, 0, ['main', 'street'], 0, 14, [0], 1, 0, [])
@@ -495,7 +495,10 @@ tape('Deserialize phrasematch results', (t) => {
     t.end();
 });
 
-
+function globalBboxForZoom(zoom) {
+    let max = (1 << zoom) - 1;
+    return [0, 0, max, max];
+}
 
 function Phrasematch(store, subquery, phrase, weight, phrase_id_range, scorefactor, prefix, mask, zoom, editMultiplier, prox_match, cat_match, partial_number, subquery_edit_distance, original_phrase, original_phrase_ender, original_phrase_mask, languages, id, idx, non_overlapping_indexes) {
     this.store = store;

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -22,7 +22,9 @@ fn coalesce_single_test_proximity_quadrants() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+            .unwrap();
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
@@ -123,7 +125,9 @@ fn coalesce_single_test_proximity_basic() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+            .unwrap();
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
@@ -175,7 +179,8 @@ fn coalesce_single_test_language_penalty() {
     builder.insert(&key, entries).expect("Unable to insert record");
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 14, 1, 1.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 14, 1, 1., global_bbox_for_zoom(14)).unwrap();
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,
@@ -579,7 +584,8 @@ fn coalesce_single_languages_test() {
     }
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 6, 1, 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 6, 1, 200., global_bbox_for_zoom(6)).unwrap();
     // Test query with all languages
     println!("Coalesce single - all languages");
     let subquery = PhrasematchSubquery {
@@ -733,7 +739,9 @@ fn coalesce_single_nearby_only() {
 
     builder.finish().unwrap();
 
-    let store = GridStore::new_with_options(directory.path(), 14, 1, 200.).unwrap();
+    let store =
+        GridStore::new_with_options(directory.path(), 14, 1, 200., global_bbox_for_zoom(14))
+            .unwrap();
     let subquery = PhrasematchSubquery {
         store: &store,
         idx: 1,


### PR DESCRIPTION
This PR now allows for indexes to, when they construct their gridstore, specify the bounding box (in tile coordinates at the given index's zoom level) of the data in the index.

In tree coalesce, as we coalesce each layer we now keep track of the bounding box of the tiles we've successfully aligned, and before deciding to explore and fetch a child's data, we confirm that the bounding box of the index corresponding to the child's phrasematch overlaps with the working bounding box that bounds the current layer's data.

For a concrete example: supposing we have a global region layer containing an "Oregon" feature, and geographically constrained indexes we're stacking on top of it, previously after fetching the region data and deciding whether to stack other indexes on top of it, those indexes only had to overlap with the region layer generally (so, because the region layer is global, this would include all indexes). Now, it only attempts fetching and stacking if the child layer overlaps with the bounds of all of the features called "oregon," which potentially excludes indexes for features outside the US.