### PR TITLE
Updated treeify-stacks benches

### DIFF
--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -34,31 +34,32 @@ pub fn benchmark(c: &mut Criterion) {
         );
     }
 
-    let to_bench = vec![
-        ("stackable_us_address", "us-address-forward.ljson.lz4"),
-        ("stackable_us_address_postcode", "us-address-postcode.ljson.lz4"),
-        (
-            "stackable_us-address_postcode_place_region",
-            "us-address-postcode-place-region.ljson.lz4",
-        ),
-    ];
-
-    for (label, file) in to_bench {
-        c.bench(
-            label,
-            Benchmark::new(label, move |b: &mut Bencher| {
-                let queries = prepare_stackable_phrasematches(file);
-                let collapsed: Vec<_> =
-                    queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
-
-                let mut cycle = collapsed.iter().cycle();
-
-                b.iter(|| {
-                    let pm = cycle.next().unwrap();
-                    stackable(&pm)
-                })
-            })
-            .sample_size(20),
-        );
-    }
+    // these need to be regenerated
+    // let to_bench = vec![
+    //     ("stackable_us_address", "us-address-forward.ljson.lz4"),
+    //     ("stackable_us_address_postcode", "us-address-postcode.ljson.lz4"),
+    //     (
+    //         "stackable_us-address_postcode_place_region",
+    //         "us-address-postcode-place-region.ljson.lz4",
+    //     ),
+    // ];
+    //
+    // for (label, file) in to_bench {
+    //     c.bench(
+    //         label,
+    //         Benchmark::new(label, move |b: &mut Bencher| {
+    //             let queries = prepare_stackable_phrasematches(file);
+    //             let collapsed: Vec<_> =
+    //                 queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
+    //
+    //             let mut cycle = collapsed.iter().cycle();
+    //
+    //             b.iter(|| {
+    //                 let pm = cycle.next().unwrap();
+    //                 stackable(&pm)
+    //             })
+    //         })
+    //         .sample_size(20),
+    //     );
+    // }
 }

--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -34,32 +34,31 @@ pub fn benchmark(c: &mut Criterion) {
         );
     }
 
-    // these need to be regenerated
-    // let to_bench = vec![
-    //     ("stackable_us_address", "us-address-forward.ljson.lz4"),
-    //     ("stackable_us_address_postcode", "us-address-postcode.ljson.lz4"),
-    //     (
-    //         "stackable_us-address_postcode_place_region",
-    //         "us-address-postcode-place-region.ljson.lz4",
-    //     ),
-    // ];
-    //
-    // for (label, file) in to_bench {
-    //     c.bench(
-    //         label,
-    //         Benchmark::new(label, move |b: &mut Bencher| {
-    //             let queries = prepare_stackable_phrasematches(file);
-    //             let collapsed: Vec<_> =
-    //                 queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
-    //
-    //             let mut cycle = collapsed.iter().cycle();
-    //
-    //             b.iter(|| {
-    //                 let pm = cycle.next().unwrap();
-    //                 stackable(&pm)
-    //             })
-    //         })
-    //         .sample_size(20),
-    //     );
-    // }
+    let to_bench = vec![
+        ("stackable_us_address", "us-address-forward.ljson.lz4"),
+        ("stackable_us_address_postcode", "us-address-postcode.ljson.lz4"),
+        (
+            "stackable_us-address_postcode_place_region",
+            "us-address-postcode-place-region.ljson.lz4",
+        ),
+    ];
+
+    for (label, file) in to_bench {
+        c.bench(
+            label,
+            Benchmark::new(label, move |b: &mut Bencher| {
+                let queries = prepare_stackable_phrasematches(file);
+                let collapsed: Vec<_> =
+                    queries.iter().map(|q| collapse_phrasematches(q.to_vec())).collect();
+
+                let mut cycle = collapsed.iter().cycle();
+
+                b.iter(|| {
+                    let pm = cycle.next().unwrap();
+                    stackable(&pm)
+                })
+            })
+            .sample_size(20),
+        );
+    }
 }

--- a/profile_osx.sh
+++ b/profile_osx.sh
@@ -10,7 +10,7 @@ fi
 # build the benchmarks
 cargo bench --no-run $1
 # find the build benchmark
-BUILD=$(ls -t target/release/benchmarks* | grep -v "\.d$" | head -n 1)
+BUILD=$(ls -t target/release/deps/benchmarks* | grep -v "\.d$" | head -n 1)
 # run benchmark, modified from http://carol-nichols.com/2017/04/20/rust-profiling-with-dtrace-on-osx/
 sudo -E dtrace -c "./$BUILD $1" -o out-$$.stacks -n 'profile-997 /pid == $target/ { @[ustack(100)] = count(); }'
 

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -451,6 +451,7 @@ pub struct MatchKeyWithId {
     #[serde(default)]
     pub nearby_only: bool,
     pub id: u32,
+    #[serde(default)]
     pub phrase_length: usize,
 }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -212,9 +212,18 @@ pub struct GridStorePlaceholder {
     max_score: f64,
 }
 
+// the data we use for stackable benches doesn't have all the fields, and we don't need them all
 #[derive(Deserialize, Debug)]
-struct SubqueryPlaceholder {
-    store: GridStorePlaceholder,
+struct MinimalGridStorePlaceholder {
+    path: String,
+    zoom: u16,
+    type_id: u16,
+    coalesce_radius: f64,
+}
+
+#[derive(Deserialize, Debug)]
+struct SubqueryPlaceholder<T> {
+    store: T,
     idx: u16,
     non_overlapping_indexes: HashSet<u32>,
     weight: f64,
@@ -234,7 +243,7 @@ pub fn prepare_phrasematches(
         .filter_map(|l| {
             let record = l.unwrap();
             if !record.is_empty() {
-                let deserialized: (Vec<SubqueryPlaceholder>, MatchOpts) =
+                let deserialized: (Vec<SubqueryPlaceholder<GridStorePlaceholder>>, MatchOpts) =
                     serde_json::from_str(&record).expect("Error deserializing json from string");
                 let stack: Vec<_> = deserialized
                     .0
@@ -300,7 +309,7 @@ pub fn prepare_stackable_phrasematches(
         .filter_map(|l| {
             let record = l.unwrap();
             if !record.is_empty() {
-                let deserialized: (Vec<SubqueryPlaceholder>, MatchOpts) =
+                let deserialized: (Vec<SubqueryPlaceholder<MinimalGridStorePlaceholder>>, MatchOpts) =
                     serde_json::from_str(&record).expect("Error deserializing json from string");
                 let stack: Vec<_> = deserialized
                     .0
@@ -311,15 +320,15 @@ pub fn prepare_stackable_phrasematches(
                                 // since stackable doesn't really need the actual gridstore data
                                 // we're using aa-country in order to avoid having to download gridstore data from every index
                                 let store_name =
-                                    "aa-country-both-3e43d23805-069d003ff2.gridstore.dat.lz4";
+                                    "aa-country-both_wvus-fa5c865008-e06f993377.gridstore.dat.lz4";
                                 let store_path = ensure_store(&store_name);
                                 let gs = GridStore::new_with_options(
                                     store_path,
                                     placeholder.store.zoom,
                                     placeholder.store.type_id,
                                     placeholder.store.coalesce_radius,
-                                    placeholder.store.bboxes.clone(),
-                                    placeholder.store.max_score,
+                                    global_bbox_for_zoom(placeholder.store.zoom),
+                                    1.0,
                                 )
                                 .unwrap();
                                 Arc::new(gs)

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -161,7 +161,7 @@ pub fn ensure_downloaded(datafile: &str) -> PathBuf {
         let client = S3Client::new(Region::UsEast1);
         let request = GetObjectRequest {
             bucket: "mapbox".to_owned(),
-            key: ("playground/apendleton/gridstore_bench_v2/".to_owned() + datafile),
+            key: ("playground/apendleton/gridstore_bench_v3/".to_owned() + datafile),
             ..Default::default()
         };
 
@@ -208,6 +208,8 @@ pub struct GridStorePlaceholder {
     zoom: u16,
     type_id: u16,
     coalesce_radius: f64,
+    bboxes: Vec<[u16; 4]>,
+    max_score: f64,
 }
 
 #[derive(Deserialize, Debug)]
@@ -253,8 +255,8 @@ pub fn prepare_phrasematches(
                                     placeholder.store.zoom,
                                     placeholder.store.type_id,
                                     placeholder.store.coalesce_radius,
-                                    global_bbox_for_zoom(placeholder.store.zoom),
-                                    1.0,
+                                    placeholder.store.bboxes.clone(),
+                                    placeholder.store.max_score,
                                 )
                                 .unwrap();
                                 Arc::new(gs)
@@ -316,8 +318,8 @@ pub fn prepare_stackable_phrasematches(
                                     placeholder.store.zoom,
                                     placeholder.store.type_id,
                                     placeholder.store.coalesce_radius,
-                                    global_bbox_for_zoom(placeholder.store.zoom),
-                                    1.0,
+                                    placeholder.store.bboxes.clone(),
+                                    placeholder.store.max_score,
                                 )
                                 .unwrap();
                                 Arc::new(gs)

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -309,8 +309,10 @@ pub fn prepare_stackable_phrasematches(
         .filter_map(|l| {
             let record = l.unwrap();
             if !record.is_empty() {
-                let deserialized: (Vec<SubqueryPlaceholder<MinimalGridStorePlaceholder>>, MatchOpts) =
-                    serde_json::from_str(&record).expect("Error deserializing json from string");
+                let deserialized: (
+                    Vec<SubqueryPlaceholder<MinimalGridStorePlaceholder>>,
+                    MatchOpts,
+                ) = serde_json::from_str(&record).expect("Error deserializing json from string");
                 let stack: Vec<_> = deserialized
                     .0
                     .iter()


### PR DESCRIPTION
Recent updates in `treeify-stacks` have added several new fields to both subqueries and gridstores to allow for new performance optimizations. The data we were using for the old coalesce benches didn't work anymore.

This PR:
- [x] switches all coalesce benches to use new `v3` data in a new s3 prefix, which has been regenerated from more recent production data (the data for the stackable benches was **not** regenerated -- none of the new fields are used in stackable, so it was easier to make those benches work with the existing data)
- [x] genericizes some of the deserialization logic so that it can be shared between the new data, which has more fields, and the old data, which lacks them
- [x] fixes the `profile_osx.sh` script for making flamegraphs, which now needs to look in a different place for compiled binaries as the layout of the `target` directory appears to have changed in recent Rust compiler versions