### PR TITLE
Deduplicate grids in tree-coalesce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ fixedbitset = "0.3.0"
 generational-arena = "0.2.7"
 indexmap = "1.3.2"
 static-bushes = { git = "https://github.com/apendleton/static-bushes.git", rev = "c4231f2e40c16be7b00bd48d2f8e444b159d6ef0" }
+fxhash = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "byteorder",
  "failure",
  "fixedbitset",
+ "fxhash",
  "generational-arena",
  "indexmap",
  "integer-encoding",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-flatbush-4",
+  "version": "0.1.1-flatbush-dedup-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-flatbush-dedup-1",
+  "version": "0.1.1-flatbush-dedup-2",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -588,7 +588,13 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
                             MAX_GRIDS_PER_PHRASE,
                         )?
                         .take(MAX_GRIDS_PER_PHRASE)
-                        .filter(|grid| unique_ids.insert((grid.grid_entry.x, grid.grid_entry.y, grid.grid_entry.id)))
+                        .filter(|grid| {
+                            unique_ids.insert((
+                                grid.grid_entry.x,
+                                grid.grid_entry.y,
+                                grid.grid_entry.id,
+                            ))
+                        })
                         .collect();
                     Ok(KeyFetchResult::Multi((key_step.key_id, data)))
                 }

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use failure::Error;
+use fxhash::FxHashSet;
 use indexmap::map::{Entry as IndexMapEntry, IndexMap};
 use itertools::Itertools;
 use min_max_heap::MinMaxHeap;
@@ -576,6 +577,7 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
 
                     Ok(KeyFetchResult::Single(step_contexts))
                 } else {
+                    let mut unique_ids = FxHashSet::default();
                     let data: Vec<_> = key_step
                         .subquery
                         .store
@@ -586,6 +588,7 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
                             MAX_GRIDS_PER_PHRASE,
                         )?
                         .take(MAX_GRIDS_PER_PHRASE)
+                        .filter(|grid| unique_ids.insert((grid.grid_entry.x, grid.grid_entry.y, grid.grid_entry.id)))
                         .collect();
                     Ok(KeyFetchResult::Multi((key_step.key_id, data)))
                 }

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixedbitset 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generational-arena 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
When grids come out of the gridstore, they're sorted by relevance, then scoredist, then whether or not the language matched. In general, if a search can surface the same feature through both an in-language and out-of-language match (e.g., "CA" with language=en can both match "California" -- in-language -- and Californien -- out-of-language), the out-of-language match will have a relevance penalty. However, if proximity is enabled and the feature is nearby, we don't apply the out-of-language penalty, so these two choices can end up tied in relevance. Previously, we relied on the fact that these features were also ordered by matches_language, and we processed them in the order we saw them in coalesce. With the flatbush change, though, the order in which we process these features is less predictable, because they're being resorted opaquely inside the spatial index, and while we sort the output from that function including matches_language on the top-level feature, we don't do so on features in the context, so that information gets lost and we have the potential to choose the wrong translation by mistake.

This branch adds an extra deduplication step on the way out of the gridstore, before we coalesce, so that if we surfaced the same x/y/id for a given phrasematch more than once, we keep the first one we see and throw away the others; if they end up differing by matches_language, we'll end up keeping the language-matching one first.

This extra dedup step does entail a bit of extra compute, but also eliminates a bunch of tiles that were being processed twice in some queries, so there's a bit of performance change, but it's mostly a wash: some queries got a little faster, some got a little slower.

![image](https://user-images.githubusercontent.com/78930/88121352-7b733400-cb93-11ea-8bf6-56fcfbefda0a.png)

Bench results ^. The biggest change was to the global autocomplete search, which improved by 15% on average. The worst was the global non-autocomplete, which got, on average, 5% worse (but was 2x faster to begin with, so this is an even smaller change in absolute terms).