### PR TITLE
Next perf round for treeify-stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0)",
+ "static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
 ]
@@ -1681,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "static-bushes"
 version = "0.1.0"
-source = "git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0#c4231f2e40c16be7b00bd48d2f8e444b159d6ef0"
+source = "git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8#114ac2ed77cf9aae6017074e85a93f79d251b4b8"
 dependencies = [
  "genawaiter 0.99.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2405,7 +2405,7 @@ dependencies = [
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum socket2 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df028e0e632c2a1823d920ad74895e7f9128e6438cbc4bc6fd1f180e644767b9"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0)" = "<none>"
+"checksum static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8)" = "<none>"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rayon = "1.3.0"
 fixedbitset = "0.3.0"
 generational-arena = "0.2.7"
 indexmap = "1.3.2"
-static-bushes = { git = "https://github.com/apendleton/static-bushes.git", rev = "c4231f2e40c16be7b00bd48d2f8e444b159d6ef0" }
+static-bushes = { git = "https://github.com/apendleton/static-bushes.git", rev = "114ac2ed77cf9aae6017074e85a93f79d251b4b8" }
 fxhash = "0.2.1"
 
 [dev-dependencies]

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 [[package]]
 name = "static-bushes"
 version = "0.1.0"
-source = "git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0#c4231f2e40c16be7b00bd48d2f8e444b159d6ef0"
+source = "git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8#114ac2ed77cf9aae6017074e85a93f79d251b4b8"
 dependencies = [
  "genawaiter",
  "num-traits",

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "neon-build",
  "neon-serde",
  "owning_ref",
+ "rayon",
  "serde",
 ]
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -21,4 +21,5 @@ serde = "1.*"
 failure = "0.1.5"
 owning_ref = "0.4"
 fixedbitset = "0.3.0"
+rayon = "1.3.0"
 carmen-core = { path = "../" }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -9,6 +9,7 @@ use neon_serde::errors::Result as LibResult;
 use serde::Deserialize;
 use owning_ref::OwningHandle;
 use failure::Error;
+use rayon;
 
 use std::sync::Arc;
 
@@ -558,6 +559,8 @@ fn prep_for_insert<'j, T: neon::object::This>(cx: &mut CallContext<'j, T>) -> Re
 }
 
 register_module!(mut m, {
+    // set thread count to 16 regardless of number of cores
+    rayon::ThreadPoolBuilder::new().num_threads(16).build_global().unwrap();
     m.export_class::<JsGridStoreBuilder>("GridStoreBuilder")?;
     m.export_class::<JsGridStore>("GridStore")?;
     m.export_class::<JsGridKeyStoreKeyIterator>("GridStoreKeyIterator")?;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-flatbush-dedup-2",
+  "version": "0.1.1-speed-tweaks-1",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.1.1-speed-tweaks-1",
+  "version": "0.1.1-speed-tweaks-2",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -380,7 +380,9 @@ impl<T: Borrow<GridStore> + Clone + Debug> CoalesceStep<'_, T> {
         };
 
         let contains_prox = if let Some(prox) = match_opts.proximity {
-            subquery.store.borrow().bboxes.iter().any(|bbox| bbox[0] <= prox[0] && bbox[2] >= prox[0] && bbox[1] <= prox[1] && bbox[3] >= prox[1])
+            subquery.store.borrow().bboxes.iter().any(|bbox| {
+                bbox[0] <= prox[0] && bbox[2] >= prox[0] && bbox[1] <= prox[1] && bbox[3] >= prox[1]
+            })
         } else {
             false
         };
@@ -391,7 +393,11 @@ impl<T: Borrow<GridStore> + Clone + Debug> CoalesceStep<'_, T> {
     #[inline(always)]
     fn cmp_key(&self) -> (OrderedFloat<f64>, bool, OrderedFloat<f64>) {
         let subquery = self.node.phrasematch.expect("phrasematch required");
-        (OrderedFloat(self.node.max_relev), self.contains_prox, OrderedFloat(subquery.store.borrow().max_score))
+        (
+            OrderedFloat(self.node.max_relev),
+            self.contains_prox,
+            OrderedFloat(subquery.store.borrow().max_score),
+        )
     }
 }
 
@@ -543,8 +549,11 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
                                 }
 
                                 // limit the number of single-word scans of high-zoom indexes (but exempt numerical autocomplete)
-                                if subquery.store.borrow().might_be_slow() && !key_group.nearby_only {
-                                    if one_word_high_zoom_range_count < ONE_WORD_HIGH_ZOOM_RANGE_QUOTA {
+                                if subquery.store.borrow().might_be_slow() && !key_group.nearby_only
+                                {
+                                    if one_word_high_zoom_range_count
+                                        < ONE_WORD_HIGH_ZOOM_RANGE_QUOTA
+                                    {
                                         one_word_high_zoom_range_count += 1;
                                     } else {
                                         continue;

--- a/test_utils/Cargo.lock
+++ b/test_utils/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "rocksdb 0.12.3 (git+https://github.com/apendleton/rust-rocksdb.git?rev=af197ad995eda9508f90ae96a625a33f83fce16d)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0)",
+ "static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8)",
 ]
 
 [[package]]
@@ -1534,7 +1534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "static-bushes"
 version = "0.1.0"
-source = "git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0#c4231f2e40c16be7b00bd48d2f8e444b159d6ef0"
+source = "git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8#114ac2ed77cf9aae6017074e85a93f79d251b4b8"
 dependencies = [
  "genawaiter 0.99.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2216,7 +2216,7 @@ dependencies = [
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum socket2 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df028e0e632c2a1823d920ad74895e7f9128e6438cbc4bc6fd1f180e644767b9"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=c4231f2e40c16be7b00bd48d2f8e444b159d6ef0)" = "<none>"
+"checksum static-bushes 0.1.0 (git+https://github.com/apendleton/static-bushes.git?rev=114ac2ed77cf9aae6017074e85a93f79d251b4b8)" = "<none>"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"


### PR DESCRIPTION
This branch has a hodgepodge of additional speed improvements.

Highlights:

## flatbush -> kdbush

I switched static `bush` datastructures from my rust port of Flatbush to my rust port of KDBush, which I hadn't ported yet when I first started this branch. That structure is more limited in terms of what it can do: it can only contain points, rather than boxes. But that's fine for our purposes (we're storing tile coordinates), and the structures are faster to build.

## A bunch of quotas

In practice, with our old carmen limits of 40 total stacks, we had two effective constraints: because each stack could have at most one autocomplete stack element (because an autocomplete element has to contain the end of the query and the end of the query can be in at most one stack), we could have at most 40 autocomplete elements, and would typically have fewer, as typically any given autocomplete element that made it into any stack would make it into more than one. Likewise, in practice we'd only have one highest-zoom component per stack, because typically these were address indexes that couldn't stack on top of one another, so we'd have at most 40 of those. I've reimposed versions of both of these limits, along with some others. The list:

- [x] renamed `SHORT_RANGE_QUOTA` to `ONE_LETTER_RANGE_QUOTA`: this is the number of single-letter autocomplete terms we'll fetch data for (still 8)
- [x] new quota `ONE_WORD_HIGH_ZOOM_RANGE_QUOTA`: this a constraint on the number of autocomplete terms that are a single word long (but potentially multiple letters) *and* come from a high-zoom index. This was to address queries like "sonoma ca" where "ca" matches "Calle" in every address index with Spanish streets in it (now 8)
- [x] new quota `ONE_WORD_RANGE_QUOTA`: this is the total number of autocomplete terms that are one word long, of any zoom -- this could only ever have been 40 in old master, because there could be at most one per stack. (now 40)
- [x] new quota `ALL_HIGH_ZOOM_RANGE_QUOTA`: this is the total number of terms that are both high-zoom and autocomplete, regardless of how many words; again, this could have been at most 40 in old master (now 40)
- [x] `ALL_HIGH_ZOOM_QUOTA`: this is the total number of high-zoom terms, autocomplete or not -- these are potentially always expensive, and some queries that have lots of fuzzy matches can produce tons, so constrain how many there can be (currently 600; there are no exact equivalents to this mechanism in old master, but this number is pretty high, so should only kick in in pathological cases)

## Limit number of threads

Rayon's default threadpools have one thread per CPU, but especially in our first-phase processing pass, we're mostly doing IO, which doesn't really scale with number of CPUs, so things kind of go haywire if we end up running on a machine with 128 cores. Now in our node bindings, we'll hard-limit this threadcount to 16.