### PR TITLE
Add bounds filter for individual phrasematches

### DIFF
--- a/benches/prod_data.rs
+++ b/benches/prod_data.rs
@@ -7,8 +7,10 @@ pub fn benchmark(c: &mut Criterion) {
     let to_bench = vec![
         ("coalesce_global", "gb_address_pm_global.ljson.lz4"),
         ("coalesce_prox", "gb_address_pm_with_proximity.ljson.lz4"),
+        ("coalesce_bounds", "gb_address_pm_with_bounds.ljson.lz4"),
         ("coalesce_ac_global", "gb_address_pm_ac_global.ljson.lz4"),
         ("coalesce_ac_prox", "gb_address_pm_ac_with_proximity.ljson.lz4"),
+        ("coalesce_ac_bounds", "gb_address_pm_ac_with_bounds.ljson.lz4"),
     ];
 
     for (label, file) in to_bench {

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
 [[package]]
 name = "neon-serde"
 version = "0.4.0"
-source = "git+https://github.com/lucasfernog/neon-serde.git?rev=a9d9164f45ff65f6f64037fe8cb3490bed357580#a9d9164f45ff65f6f64037fe8cb3490bed357580"
+source = "git+https://github.com/mattciferri/neon-serde.git?rev=a9d9164f45ff65f6f64037fe8cb3490bed357580#a9d9164f45ff65f6f64037fe8cb3490bed357580"
 dependencies = [
  "error-chain",
  "neon",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -17,7 +17,7 @@ neon-build = "0.7.1"
 [dependencies]
 neon = "0.7.1"
 # neon-serde branch that supports neon 0.7, until https://github.com/GabrielCastro/neon-serde/pull/67 lands
-neon-serde = { git = "https://github.com/lucasfernog/neon-serde.git", rev="a9d9164f45ff65f6f64037fe8cb3490bed357580" }
+neon-serde = { git = "https://github.com/mattciferri/neon-serde.git", rev="a9d9164f45ff65f6f64037fe8cb3490bed357580" }
 serde = "1.*"
 failure = "0.1.5"
 owning_ref = "0.4"

--- a/native/src/gridstore.rs
+++ b/native/src/gridstore.rs
@@ -543,8 +543,8 @@ where
             js_nearby_only.downcast::<JsBoolean>().or_throw(cx)?.value()
         };
 
-        let js_bbox = js_phrasematch.get(cx, "bbox")?;
-        let bbox: Option<[u16; 4]> = neon_serde::from_value(cx, js_bbox)?;
+        let js_bounds = js_phrasematch.get(cx, "bounds")?;
+        let bounds: Option<[u16; 4]> = neon_serde::from_value(cx, js_bounds)?;
 
         let js_non_overlapping_indexes = js_phrasematch.get(cx, "non_overlapping_indexes")?;
         let non_overlapping_indexes: Vec<u32> =

--- a/native/src/gridstore.rs
+++ b/native/src/gridstore.rs
@@ -543,6 +543,9 @@ where
             js_nearby_only.downcast::<JsBoolean>().or_throw(cx)?.value()
         };
 
+        let js_bbox = js_phrasematch.get(cx, "bbox")?;
+        let bbox: Option<[u16; 4]> = neon_serde::from_value(cx, js_bbox)?;
+
         let js_non_overlapping_indexes = js_phrasematch.get(cx, "non_overlapping_indexes")?;
         let non_overlapping_indexes: Vec<u32> =
             neon_serde::from_value(cx, js_non_overlapping_indexes)?;
@@ -558,6 +561,7 @@ where
                 id: neon_serde::from_value(cx, id)?,
                 nearby_only,
                 phrase_length,
+                bounds,
             }],
             mask: neon_serde::from_value(cx, mask)?,
             idx: neon_serde::from_value(cx, idx)?,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.3.0-bounds",
+  "version": "0.4.0",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/carmen-core",
-  "version": "0.3.0",
+  "version": "0.3.0-bounds",
   "description": "node bindings for carmen-core",
   "main": "index.js",
   "engines": {

--- a/rust-src/src/gridstore/coalesce.rs
+++ b/rust-src/src/gridstore/coalesce.rs
@@ -513,8 +513,8 @@ pub fn tree_coalesce<T: Borrow<GridStore> + Clone + Debug + Send + Sync>(
 
                 for key_group in subquery.match_keys.iter() {
                     if is_single || !data_cache.contains_key(&key_group.id) {
-                        let match_opts = if key_group.nearby_only {
-                            step.match_opts.with_nearby_only()
+                        let match_opts = if key_group.nearby_only || key_group.bounds.is_some() {
+                            step.match_opts.augment_bbox(key_group.nearby_only, key_group.bounds)
                         } else {
                             step.match_opts.clone()
                         };

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -155,35 +155,48 @@ impl MatchOpts {
         }
     }
 
-    pub fn with_nearby_only(&self) -> MatchOpts {
-        let mut constrained = self.clone();
-        let prox = if let Some(prox) = constrained.proximity {
-            prox.clone()
+    pub fn augment_bbox(&self, nearby_only: bool, bounds: Option<[u16; 4]>) -> MatchOpts {
+        let mut augmented = self.clone();
+
+        let nearby_buffer = if nearby_only {
+            match augmented.proximity {
+                None => None,
+                Some(prox) => {
+                    let miles_per_tile = EARTH_CIRC_IN_MILES / ((1 << augmented.zoom) as f64);
+                    let padding = (NEARBY_RADIUS / miles_per_tile).ceil() as u16;
+
+                    Some([
+                        if prox[0] < padding { 0 } else { prox[0] - padding }, // prevent overflows because this is unsigned
+                        if prox[1] < padding { 0 } else { prox[1] - padding }, // ditto
+                        prox[0] + padding,
+                        prox[1] + padding,
+                    ])
+                }
+            }
         } else {
-            return constrained;
+            None
         };
 
-        let miles_per_tile = EARTH_CIRC_IN_MILES / ((1 << constrained.zoom) as f64);
-        let padding = (NEARBY_RADIUS / miles_per_tile).ceil() as u16;
+        let new_bbox = [augmented.bbox, nearby_buffer, bounds].iter().fold(None, |acc, &curr| {
+           match (acc, curr) {
+               (Some(acc), Some(curr)) => Some(Self::bbox_intersect(acc, curr)),
+               (Some(acc), None) => Some(acc),
+               (None, Some(curr)) => Some(curr),
+               (None, None) => None,
+           }
+        });
 
-        let mut new_box: [u16; 4] = [
-            if prox[0] < padding { 0 } else { prox[0] - padding }, // prevent overflows because this is unsigned
-            if prox[1] < padding { 0 } else { prox[1] - padding }, // ditto
-            prox[0] + padding,
-            prox[1] + padding,
-        ];
+        augmented.bbox = new_bbox;
+        augmented
+    }
 
-        if let Some(old_box) = constrained.bbox {
-            new_box = [
-                std::cmp::max(old_box[0], new_box[0]),
-                std::cmp::max(old_box[1], new_box[1]),
-                std::cmp::min(old_box[2], new_box[2]),
-                std::cmp::min(old_box[3], new_box[3]),
-            ]
-        }
-
-        constrained.bbox = Some(new_box);
-        constrained
+    fn bbox_intersect(left: [u16; 4], right: [u16; 4]) -> [u16; 4] {
+        [
+            std::cmp::max(left[0], right[0]),
+            std::cmp::max(left[1], right[1]),
+            std::cmp::min(left[2], right[2]),
+            std::cmp::min(left[3], right[3]),
+        ]
     }
 }
 
@@ -334,20 +347,20 @@ mod tests {
     fn nearby_only() {
         let opts = matchopts_proximity_generator([100, 100], 14);
         assert_eq!(
-            opts.with_nearby_only(),
+            opts.augment_bbox(true, None),
             MatchOpts { bbox: Some([83, 83, 117, 117]), proximity: Some([100, 100]), zoom: 14 }
         );
 
         let opts = matchopts_proximity_generator([100, 100], 6);
         assert_eq!(
-            opts.with_nearby_only(),
+            opts.augment_bbox(true, None),
             MatchOpts { bbox: Some([99, 99, 101, 101]), proximity: Some([100, 100]), zoom: 6 }
         );
 
         // truncate at the antemeridian
         let opts = matchopts_proximity_generator([5, 5], 14);
         assert_eq!(
-            opts.with_nearby_only(),
+            opts.augment_bbox(true, None),
             MatchOpts { bbox: Some([0, 0, 22, 22]), proximity: Some([5, 5]), zoom: 14 }
         );
 
@@ -355,8 +368,39 @@ mod tests {
         let mut opts = matchopts_proximity_generator([100, 100], 14);
         opts.bbox = Some([90, 70, 115, 180]);
         assert_eq!(
-            opts.with_nearby_only(),
+            opts.augment_bbox(true, None),
             MatchOpts { bbox: Some([90, 83, 115, 117]), proximity: Some([100, 100]), zoom: 14 }
+        );
+    }
+
+    #[test]
+    fn bounds() {
+        // test bounds are properly set on match_opts
+        let opts = MatchOpts { bbox: None, proximity: None, zoom: 14 };
+        assert_eq!(
+            opts.augment_bbox(false, Some([1, 2, 3, 4])),
+            MatchOpts { bbox: Some([1, 2, 3, 4]), proximity: None, zoom: 14 }
+        );
+
+        // test intersection of user bbox, nearby_only buffer, and bounds
+        let opts = MatchOpts { bbox: Some([75, 75, 115, 125]), proximity: Some([100, 100]), zoom: 14 };
+        assert_eq!(
+            opts.augment_bbox(true, Some([100, 100, 135, 135])),
+            MatchOpts { bbox: Some([100, 100, 115, 117]), proximity: Some([100, 100]), zoom: 14 }
+        );
+
+        // test intersection of nearby_only buffer and bounds
+        let opts = MatchOpts { bbox: None, proximity: Some([60, 60]), zoom: 14 };
+        assert_eq!(
+            opts.augment_bbox(true, Some([50, 50, 80, 80])),
+            MatchOpts { bbox: Some([50, 50, 77, 77]), proximity: Some([60, 60]), zoom: 14 }
+        );
+
+        // nearby_only buffer not applied without a proximity point
+        let opts = MatchOpts { bbox: Some([60, 60, 70, 70]), proximity: None, zoom: 14 };
+        assert_eq!(
+            opts.augment_bbox(true, Some([50, 50, 75, 75])),
+            MatchOpts { bbox: Some([60, 60, 70, 70]), proximity: None, zoom: 14 }
         );
     }
 }
@@ -453,6 +497,7 @@ pub struct MatchKeyWithId {
     pub id: u32,
     #[serde(default)]
     pub phrase_length: usize,
+    pub bounds: Option<[u16; 4]>,
 }
 
 impl Default for MatchKeyWithId {
@@ -464,6 +509,7 @@ impl Default for MatchKeyWithId {
             // default is 2 because 1 has special behaviors that we might not want to opt into
             // in the typical test case
             phrase_length: 2,
+            bounds: None,
         }
     }
 }

--- a/rust-src/src/gridstore/common.rs
+++ b/rust-src/src/gridstore/common.rs
@@ -177,14 +177,17 @@ impl MatchOpts {
             None
         };
 
-        let new_bbox = [augmented.bbox, nearby_buffer, bounds].iter().fold(None, |acc, &curr| {
-           match (acc, curr) {
-               (Some(acc), Some(curr)) => Some(Self::bbox_intersect(acc, curr)),
-               (Some(acc), None) => Some(acc),
-               (None, Some(curr)) => Some(curr),
-               (None, None) => None,
-           }
-        });
+        // There are three bounding boxes at play here, each of which are optional. If there is only one, return it.
+        // If there is more than one, return the intersection of them.
+        let new_bbox =
+            [augmented.bbox, nearby_buffer, bounds].iter().fold(None, |acc, &curr| {
+                match (acc, curr) {
+                    (Some(acc), Some(curr)) => Some(Self::bbox_intersect(acc, curr)),
+                    (Some(acc), None) => Some(acc),
+                    (None, Some(curr)) => Some(curr),
+                    (None, None) => None,
+                }
+            });
 
         augmented.bbox = new_bbox;
         augmented
@@ -383,7 +386,8 @@ mod tests {
         );
 
         // test intersection of user bbox, nearby_only buffer, and bounds
-        let opts = MatchOpts { bbox: Some([75, 75, 115, 125]), proximity: Some([100, 100]), zoom: 14 };
+        let opts =
+            MatchOpts { bbox: Some([75, 75, 115, 125]), proximity: Some([100, 100]), zoom: 14 };
         assert_eq!(
             opts.augment_bbox(true, Some([100, 100, 135, 135])),
             MatchOpts { bbox: Some([100, 100, 115, 117]), proximity: Some([100, 100]), zoom: 14 }

--- a/tests/coalesce_test.rs
+++ b/tests/coalesce_test.rs
@@ -770,7 +770,6 @@ fn coalesce_single_nearby_only() {
     );
 }
 
-
 #[test]
 fn coalesce_single_test_bounds() {
     let directory: tempfile::TempDir = tempfile::tempdir().unwrap();
@@ -814,11 +813,7 @@ fn coalesce_single_test_bounds() {
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     let result_ids: Vec<u32> =
         tree_result.iter().map(|context| context.entries[0].grid_entry.id).collect();
-    assert_eq!(
-        result_ids,
-        [4, 1, 3],
-        "Results are restricted to bounds"
-    );
+    assert_eq!(result_ids, [4, 1, 3], "Results are restricted to bounds");
 
     println!("Coalesce single - bounds with nearby_only buffer");
     let subquery = PhrasematchSubquery {
@@ -863,7 +858,12 @@ fn coalesce_single_test_bounds() {
         mask: 1 << 0,
     };
     let stack = vec![subquery];
-    let match_opts = MatchOpts { zoom: 14, proximity: Some([100, 100]), bbox: Some([40, 40, 95, 95]), ..MatchOpts::default() };
+    let match_opts = MatchOpts {
+        zoom: 14,
+        proximity: Some([100, 100]),
+        bbox: Some([40, 40, 95, 95]),
+        ..MatchOpts::default()
+    };
     let tree = stackable(&stack);
     let tree_result = truncate_coalesce_results(tree_coalesce(&tree, &match_opts).unwrap());
     let result_ids: Vec<u32> =

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,12 +108,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-agent-base@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  dependencies:
-    es6-promisify "^5.0.0"
-
 ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -175,16 +169,6 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
-
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  dependencies:
-    sprintf-js "~1.0.2"
-
-argv@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
 
 array-back@^3.0.1:
   version "3.1.0"
@@ -463,7 +447,7 @@ d3-queue@^3.0.2, d3-queue@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.7.tgz#c93a2e54b417c0959129d7d73f6cf7d4292e7618"
 
-debug@^3.1.0, debug@^3.2.6:
+debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -596,23 +580,9 @@ es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
 
-es6-promise@^4.0.3:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  dependencies:
-    es6-promise "^4.0.3"
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -831,13 +801,6 @@ hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
-  dependencies:
-    agent-base "^4.1.0"
-    debug "^3.1.0"
-
 iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1038,13 +1001,6 @@ jmespath@0.15.0:
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
-
-js-yaml@^3.12.0:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -1304,10 +1260,6 @@ nested-error-stacks@^2.0.0:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-
-node-fetch@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
 
 node-pre-gyp@~0.13.0:
   version "0.13.0"
@@ -1823,10 +1775,6 @@ spdx-license-ids@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
 
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -1973,14 +1921,6 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-teeny-request@^3.7.0:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
-  dependencies:
-    https-proxy-agent "^2.2.1"
-    node-fetch "^2.2.0"
-    uuid "^3.3.2"
-
 test-exclude@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.2.tgz#7322f8ab037b0b93ad2aab35fe9068baf997a4c4"
@@ -2054,10 +1994,6 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-urlgrey@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR enables an additional parameter for phrasematches, `bounds`, which limits results to a provided bounding box. This is unique from the bbox passed into coalesce through match_opts, which is global bbox for the entire query. Rather, `bounds` can be applied to individual phrasematches, which can be useful in cases where we want to limit results from a particular index (that may contain many similar potential matches) to a smaller geographic area than the index covers.

The `bounds` parameter is applied to match_opts before fetching from the gridstore in a similar manner to the `nearby_only` parameter. Now that there are three potential bboxes that can be applied at this stage (bounds, the buffer created by nearby_only, and the user-provided bbox), we take the intersection of those that exist and use that for the coalesce operation.

### Summary of changes
- Parses the `bounds` parameter in the phrasematch object in the neon wrapper
- Augments the bbox in MatchOpts to become the intersect of the bounds, the provided bbox, and the proximity buffer. This happens before fetching gridstore results.
- Adds new benchmark files to test phrasematches with bounds
- Cuts over to my own fork of neon-serde, as the current one no longer exists